### PR TITLE
fix: hide chat list when no project selected; remove ANTHROPIC_API_KEY from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ claude-code-chat/
 
 ```env
 PORT=3000
-ANTHROPIC_API_KEY=        # SDK mode only; leave empty for CLI mode (Max subscription)
 SESSION_SECRET=           # Auto-generated if empty
 WORKDIR=./workspace       # Claude's working directory
 TRUST_PROXY=false         # Set true behind nginx/Caddy

--- a/README_RU.md
+++ b/README_RU.md
@@ -112,7 +112,6 @@ claude-code-chat/
 
 ```env
 PORT=3000
-ANTHROPIC_API_KEY=        # Только для SDK режима; оставить пустым для CLI (Max подписка)
 SESSION_SECRET=           # Генерируется автоматически если пусто
 WORKDIR=./workspace       # Рабочая директория Claude
 TRUST_PROXY=false         # Установить true за nginx/Caddy

--- a/README_UA.md
+++ b/README_UA.md
@@ -112,7 +112,6 @@ claude-code-chat/
 
 ```env
 PORT=3000
-ANTHROPIC_API_KEY=        # Лише для SDK режиму; залишити порожнім для CLI (Max підписка)
 SESSION_SECRET=           # Генерується автоматично якщо порожнє
 WORKDIR=./workspace       # Робоча директорія Claude
 TRUST_PROXY=false         # Встановити true за nginx/Caddy

--- a/public/index.html
+++ b/public/index.html
@@ -2094,10 +2094,10 @@ async function loadStats() {
 // ─── Session History ──────────────────────────────────────────────────────
 async function loadHist() {
   try {
-    const url = curWorkdir ? `/api/sessions?workdir=${encodeURIComponent(curWorkdir)}` : '/api/sessions';
-    const r = await fetch(url);
-    const ss = await r.json();
     const el = $i('histList');
+    if (!curWorkdir) { el.innerHTML = ''; $i('histCount').textContent = ''; return; }
+    const r = await fetch(`/api/sessions?workdir=${encodeURIComponent(curWorkdir)}`);
+    const ss = await r.json();
     el.innerHTML = '';
     $i('histCount').textContent = ss.length || '';
     for (const s of ss) {


### PR DESCRIPTION
## Summary
- Hide chat list when no project is selected (closes #4)
- Remove `ANTHROPIC_API_KEY=` from env example blocks in all README files (closes #3)

## Test plan
- [ ] Open app without selecting a project → sidebar chat list is empty
- [ ] Select a project → sidebar shows only chats for that project
- [ ] Verify README.md, README_RU.md, README_UA.md no longer show ANTHROPIC_API_KEY in env block

🤖 Generated with [Claude Code](https://claude.com/claude-code)