### PR TITLE
Add .gitattributes for Git LFS tracking of large video assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+public/videos/*.gif filter=lfs diff=lfs merge=lfs -text
+public/videos/*.mp4 filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Problem

`npm install -g github:Lexus2016/claude-code-studio` fails with an unexpected EOF error:

```
npm error code EOF
npm error syscall read
npm error path .../_cacache/tmp/git-clone.../public/videos/new_release_video.gif
npm error encountered unexpected EOF
```

This also prevents installation via `mise use -g github:Lexus2016/claude-code-studio` (no matching assets for any platform).

The root cause is two large binary files stored directly in git objects:

| File | Size |
|------|------|
| `public/videos/new_release_video.gif` | 24.8 MB |
| `public/videos/new_release_video.mp4` | 9 MB |

When npm downloads the repo tarball and tries to extract/cache it, the oversized GIF causes the tar stream to truncate.

## What this PR does

Adds a `.gitattributes` file to track `public/videos/*.gif` and `public/videos/*.mp4` with Git LFS.

## Required follow-up (maintainer action)

This PR alone adds the tracking rules but does not migrate the existing files into LFS. After merging, you'll need to run:

```bash
git lfs install
git lfs migrate import --include="public/videos/*.gif,public/videos/*.mp4" --everything
git push --force-with-lease
```

This rewrites history to move the large files into LFS storage, which is why it requires a force push and can only be done by the maintainer.

## Environment

- macOS 14+ (arm64)
- npm 11.x / node 25.x
- Also reproducible with `npx github:Lexus2016/claude-code-studio`