### PR TITLE
fix(tasks): do not mark a usage-limited task Done — pause it and auto-resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ docker compose up -d
 docker compose logs -f claude-chat
 ```
 
-No linting and no build step configured. `npm test` chains 27 test files under `test/`: 10 DOM-less render/UI-logic tests (`test/render/*.test.mjs`, run through `node --test`) plus 17 plain-`node` suites in `test/` covering the overload detector, env load order, multi-agent results, terminals, bots, telegram, updates, kanban scheduling, i18n completeness and WS session re-subscription. It runs serially and aborts on the first failing file. No CI is wired up yet.
+No linting and no build step configured. `npm test` chains 30 test files under `test/`: 10 DOM-less render/UI-logic tests (`test/render/*.test.mjs`, run through `node --test`) plus 20 plain-`node` suites in `test/` covering the overload detector, env load order, multi-agent results, terminals, bots, telegram, updates, kanban scheduling, i18n completeness, usage-limit detection and WS session re-subscription. It runs serially and aborts on the first failing file. No CI is wired up yet.
 
 ## Architecture
 
@@ -159,7 +159,7 @@ These short aliases are exactly what `claude-cli.js` (`MODEL_MAP`) passes to the
 
 ## How to Verify Changes
 
-`npm test` runs 27 test files under `test/` (10 `test/render/*.test.mjs` + 17 `test/*.test.js`). There is no CI yet, and nothing covers the live browser/WebSocket path, so also verify that manually:
+`npm test` runs 30 test files under `test/` (10 `test/render/*.test.mjs` + 20 `test/*.test.js`). There is no CI yet, and nothing covers the live browser/WebSocket path, so also verify that manually:
 
 ```bash
 # 1. Start server

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node --watch server.js",
-    "test": "node --test test/render/*.test.mjs && node test/overload-detector.test.js && node test/env-load-order.test.js && node test/multi-agent-result.test.js && node test/terminal-session.test.js && node test/terminal-schema.test.js && node test/bots.test.js && node test/bots-api.test.js && node test/running-sessions.test.js && node test/session-liveness.test.js && node test/terminal-bridge.integration.test.js && node test/telegram-format.test.js && node test/telegram-behaviour.test.js && node test/ask-user-question.test.js && node test/delegate-terminal.test.js && node test/update-flow.test.js && node test/kanban-schedule.test.js && node test/i18n-completeness.test.js && node test/setup-gate.test.js && node test/subscribe-nocatchup.test.js",
+    "test": "node --test test/render/*.test.mjs && node test/overload-detector.test.js && node test/usage-limit.test.js && node test/env-load-order.test.js && node test/multi-agent-result.test.js && node test/terminal-session.test.js && node test/terminal-schema.test.js && node test/bots.test.js && node test/bots-api.test.js && node test/running-sessions.test.js && node test/session-liveness.test.js && node test/terminal-bridge.integration.test.js && node test/telegram-format.test.js && node test/telegram-behaviour.test.js && node test/ask-user-question.test.js && node test/delegate-terminal.test.js && node test/update-flow.test.js && node test/kanban-schedule.test.js && node test/i18n-completeness.test.js && node test/setup-gate.test.js && node test/subscribe-nocatchup.test.js",
     "postinstall": "node scripts/install-hooks.js",
     "release": "node scripts/release.js",
     "electron:dev": "electron .",

--- a/public/index.html
+++ b/public/index.html
@@ -148,6 +148,7 @@ button:focus-visible, a:focus-visible { border-radius: 5px; }
 @keyframes actPulse { 0%{box-shadow:0 0 0 0 rgba(34,197,94,.5)} 70%{box-shadow:0 0 0 5px rgba(34,197,94,0)} 100%{box-shadow:0 0 0 0 rgba(34,197,94,0)} }
 .act-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .act-meta { font-size: 10px; color: var(--muted); flex-shrink: 0; font-variant-numeric: tabular-nums; }
+.act-paused { color: var(--orange); }
 .act-src { font-size: 9px; font-weight: 700; text-transform: uppercase; padding: 1px 4px; border-radius: 3px; background: var(--s3, #1f2637); color: var(--muted); flex-shrink: 0; }
 .act-proj { font-size: 9px; color: var(--accent2); opacity: .85; flex-shrink: 0; }
 .act-empty { font-size: 11px; color: var(--muted); opacity: .55; padding: 8px 6px; text-align: center; }
@@ -4363,7 +4364,7 @@ const TRANSLATIONS = {
     'agent.modal.newIdCommand.label':'Команда створення розмови','agent.modal.newIdCommand.hint':'Альтернатива прапорцю: команда, що створює розмову і друкує її id. Виконується один раз при створенні сесії.',
     'agent.modal.interactive.label':'Інтерактивна команда','agent.modal.interactive.hint':'Запускає TUI агента для термінальної сесії. Порожньо — агент лише для делегування.','agent.modal.resume.label':'Команда відновлення','agent.modal.resume.hint':'{sid} — ідентифікатор розмови. Використовується для відновлення сесії після перезавантаження.','agent.modal.resumeLast.label':'Відновити останню (запасний варіант)','agent.modal.resumeLast.hint':'Використовується, коли ідентифікатор невідомий. Може відновити іншу розмову.','agent.modal.newIdFlag.label':'Прапорець id нової розмови','agent.modal.newIdFlag.hint':'Якщо CLI дозволяє задати id НОВОЇ розмови, відновлення стає точним. Порожньо — не підтримується.',
     'export.btn':'Експорт','export.title':'Експортувати розмову','notes.btn':'Нотатки','notes.title':'Нотатки сесії (приватні)','notes.ph':'Приватні нотатки сесії — не надсилаються Claude...','notes.save':'Зберегти','notes.saved':'✓ Збережено',
-    'act.title':'Активність','act.group':'Групувати за проєктами ↔ плоский список','act.live':'Активні','act.scheduled':'Заплановані','act.recent':'Нещодавні','act.empty':'Немає активності','act.recovering':'віднов.','act.now':'зараз','act.in':'за','act.u.s':'с','act.u.m':'хв','act.u.h':'г','act.u.d':'д',
+    'act.title':'Активність','act.paused':'пауза: ліміт','act.paused_tip':'Зупинено лімітом використання — відновиться автоматично','act.group':'Групувати за проєктами ↔ плоский список','act.live':'Активні','act.scheduled':'Заплановані','act.recent':'Нещодавні','act.empty':'Немає активності','act.recovering':'віднов.','act.now':'зараз','act.in':'за','act.u.s':'с','act.u.m':'хв','act.u.h':'г','act.u.d':'д',
     'sec.proactive':'Статус',
     'sec.chats':'Чати','sec.mcp':'MCP',
     'mcp.hint':'Увімкніть інструменти, які Claude може використовувати в цьому чаті.',
@@ -4611,7 +4612,7 @@ const TRANSLATIONS = {
     'agent.modal.newIdCommand.label':'New-conversation command','agent.modal.newIdCommand.hint':'Alternative to the flag: a command that creates a conversation and prints its id. Run once when the session is created.',
     'agent.modal.interactive.label':'Interactive command','agent.modal.interactive.hint':"Starts the agent's TUI for a terminal session. Leave empty for a delegation-only agent.",'agent.modal.resume.label':'Resume command','agent.modal.resume.hint':'{sid} — the conversation id. Used to restore the session after a reboot.','agent.modal.resumeLast.label':'Resume last (fallback)','agent.modal.resumeLast.hint':'Used when no conversation id is known. May restore a different conversation.','agent.modal.newIdFlag.label':'New-conversation id flag','agent.modal.newIdFlag.hint':'If the CLI can be told the id of a NEW conversation, restore becomes exact. Leave empty if unsupported.',
     'export.btn':'Export','export.title':'Export conversation','notes.btn':'Notes','notes.title':'Session notes (private)','notes.ph':'Private session notes — not sent to Claude...','notes.save':'Save','notes.saved':'✓ Saved',
-    'act.title':'Activity','act.group':'Group by project ↔ flat list','act.live':'Active','act.scheduled':'Scheduled','act.recent':'Recent','act.empty':'No activity','act.recovering':'recovering','act.now':'now','act.in':'in','act.u.s':'s','act.u.m':'m','act.u.h':'h','act.u.d':'d',
+    'act.title':'Activity','act.paused':'paused: limit','act.paused_tip':'Stopped by a usage limit — resumes automatically','act.group':'Group by project ↔ flat list','act.live':'Active','act.scheduled':'Scheduled','act.recent':'Recent','act.empty':'No activity','act.recovering':'recovering','act.now':'now','act.in':'in','act.u.s':'s','act.u.m':'m','act.u.h':'h','act.u.d':'d',
     'sec.proactive':'Status',
     'sec.chats':'Chats','sec.mcp':'MCP',
     'mcp.hint':'Enable tools that Claude can use in this chat.',
@@ -4859,7 +4860,7 @@ const TRANSLATIONS = {
     'agent.modal.newIdCommand.label':'Команда создания разговора','agent.modal.newIdCommand.hint':'Альтернатива флагу: команда, создающая разговор и печатающая его id. Выполняется один раз при создании сессии.',
     'agent.modal.interactive.label':'Интерактивная команда','agent.modal.interactive.hint':'Запускает TUI агента для терминальной сессии. Пусто — агент только для делегирования.','agent.modal.resume.label':'Команда восстановления','agent.modal.resume.hint':'{sid} — идентификатор разговора. Используется для восстановления сессии после перезагрузки.','agent.modal.resumeLast.label':'Восстановить последний (запасной вариант)','agent.modal.resumeLast.hint':'Используется, когда идентификатор неизвестен. Может восстановить другой разговор.','agent.modal.newIdFlag.label':'Флаг id нового разговора','agent.modal.newIdFlag.hint':'Если CLI позволяет задать id НОВОГО разговора, восстановление становится точным. Пусто — не поддерживается.',
     'export.btn':'Экспорт','export.title':'Экспортировать разговор','notes.btn':'Заметки','notes.title':'Заметки сессии (приватные)','notes.ph':'Приватные заметки сессии — не отправляются Claude...','notes.save':'Сохранить','notes.saved':'✓ Сохранено',
-    'act.title':'Активность','act.group':'Группировать по проектам ↔ плоский список','act.live':'Активные','act.scheduled':'Запланированные','act.recent':'Недавние','act.empty':'Нет активности','act.recovering':'восст.','act.now':'сейчас','act.in':'через','act.u.s':'с','act.u.m':'мин','act.u.h':'ч','act.u.d':'д',
+    'act.title':'Активность','act.paused':'пауза: лимит','act.paused_tip':'Остановлено лимитом использования — возобновится автоматически','act.group':'Группировать по проектам ↔ плоский список','act.live':'Активные','act.scheduled':'Запланированные','act.recent':'Недавние','act.empty':'Нет активности','act.recovering':'восст.','act.now':'сейчас','act.in':'через','act.u.s':'с','act.u.m':'мин','act.u.h':'ч','act.u.d':'д',
     'sec.proactive':'Статус',
     'sec.chats':'Чаты','sec.mcp':'MCP',
     'mcp.hint':'Включите инструменты, которые Claude может использовать в этом чате.',
@@ -5107,7 +5108,7 @@ const TRANSLATIONS = {
     "agent.modal.newIdCommand.label":"Commande de nouvelle conversation","agent.modal.newIdCommand.hint":"Alternative à l'indicateur : une commande qui crée une conversation et affiche son id. Exécutée une fois à la création de la session.",
     "agent.modal.interactive.label":"Commande interactive","agent.modal.interactive.hint":"Lance le TUI de l'agent pour une session terminal. Vide — agent de délégation uniquement.","agent.modal.resume.label":"Commande de reprise","agent.modal.resume.hint":"{sid} — identifiant de la conversation. Sert à restaurer la session après un redémarrage.","agent.modal.resumeLast.label":"Reprendre la dernière (repli)","agent.modal.resumeLast.hint":"Utilisée quand aucun identifiant n'est connu. Peut restaurer une autre conversation.","agent.modal.newIdFlag.label":"Indicateur d'id de nouvelle conversation","agent.modal.newIdFlag.hint":"Si la CLI accepte l'id d'une NOUVELLE conversation, la restauration devient exacte. Vide si non pris en charge.",
     "export.btn":"Exporter","export.title":"Exporter la conversation","notes.btn":"Notes","notes.title":"Notes de session (privées)","notes.ph":"Notes de session privées — non envoyées à Claude...",
-    "notes.save":"Enregistrer","notes.saved":"✓ Enregistré","act.title":"Activité","act.group":"Regrouper par projet ↔ liste à plat","act.live":"Actif","act.scheduled":"Planifié","act.recent":"Récent",
+    "notes.save":"Enregistrer","notes.saved":"✓ Enregistré","act.title":"Activité","act.paused":"pause : limite","act.paused_tip":"Arrêté par une limite d'utilisation — reprise automatique","act.group":"Regrouper par projet ↔ liste à plat","act.live":"Actif","act.scheduled":"Planifié","act.recent":"Récent",
     "act.empty":"Aucune activité","act.recovering":"récupération","act.now":"maintenant","act.in":"dans","act.u.s":"s","act.u.m":"m","act.u.h":"h","act.u.d":"j","sec.proactive":"Statut",
     "sec.chats":"Chats","sec.mcp":"MCP","mcp.hint":"Activez les outils que Claude peut utiliser dans ce chat.","mcp.add":"＋ Ajouter un serveur MCP","mcp.id":"ID (ex. my-server)","mcp.label":"Libellé",
     "mcp.cmd":"Commande (ex. npx)","mcp.args":"Arguments séparés par des virgules","mcp.add_btn":"Ajouter","sec.skills":"Compétences",
@@ -5256,7 +5257,7 @@ const TRANSLATIONS = {
     "agent.modal.newIdCommand.label":"פקודת יצירת שיחה","agent.modal.newIdCommand.hint":"חלופה לדגל: פקודה שיוצרת שיחה ומדפיסה את המזהה שלה. מורצת פעם אחת ביצירת השיחה.",
     "agent.modal.interactive.label":"פקודה אינטראקטיבית","agent.modal.interactive.hint":"מפעילה את ה-TUI של הסוכן עבור שיחת טרמינל. ריק — סוכן להאצלה בלבד.","agent.modal.resume.label":"פקודת שחזור","agent.modal.resume.hint":"{sid} — מזהה השיחה. משמש לשחזור השיחה לאחר הפעלה מחדש.","agent.modal.resumeLast.label":"שחזר אחרונה (גיבוי)","agent.modal.resumeLast.hint":"משמש כאשר המזהה אינו ידוע. עשוי לשחזר שיחה אחרת.","agent.modal.newIdFlag.label":"דגל מזהה לשיחה חדשה","agent.modal.newIdFlag.hint":"אם ה-CLI מאפשר לקבוע מזהה לשיחה חדשה, השחזור נעשה מדויק. ריק אם אינו נתמך.",
     "export.btn":"ייצוא","export.title":"ייצוא שיחה","notes.btn":"הערות","notes.title":"הערות סשן (פרטי)","notes.ph":"הערות פרטיות לסשן — לא נשלחות ל-Claude...","notes.save":"שמירה",
-    "notes.saved":"✓ נשמר","act.title":"פעילות","act.group":"קיבוץ לפי פרויקט ↔ רשימה שטוחה","act.live":"פעיל","act.scheduled":"מתוזמן","act.recent":"אחרונים","act.empty":"אין פעילות",
+    "notes.saved":"✓ נשמר","act.title":"פעילות","act.paused":"מושהה: מגבלה","act.paused_tip":"נעצר עקב מגבלת שימוש — יתחדש אוטומטית","act.group":"קיבוץ לפי פרויקט ↔ רשימה שטוחה","act.live":"פעיל","act.scheduled":"מתוזמן","act.recent":"אחרונים","act.empty":"אין פעילות",
     "act.recovering":"מתאושש","act.now":"עכשיו","act.in":"בעוד","act.u.s":"שנ'","act.u.m":"דק'","act.u.h":"שע'","act.u.d":"יום","sec.proactive":"סטטוס","sec.chats":"צ'אטים","sec.mcp":"MCP",
     "mcp.hint":"הפעילו כלים ש-Claude יוכל להשתמש בהם בצ'אט הזה.","mcp.add":"＋ הוספת שרת MCP","mcp.id":"ID (לדוגמה my-server)","mcp.label":"תווית","mcp.cmd":"פקודה (לדוגמה npx)",
     "mcp.args":"ארגומנטים מופרדים בפסיקים","mcp.add_btn":"הוספה","sec.skills":"Skills","skills.hint":"Skills הם קובצי הנחיות שמתווספים ל-system prompt.","skills.upload":"＋ העלאת קובץ .md",
@@ -10696,7 +10697,11 @@ function _actItemHtml(it, kind) {
   }
   if (kind === 'scheduled') {
     const rec = it.recurrence ? ' ↻' : '';
-    return `<div class="act-item${staticCls}" ${onclick}><span class="act-dot sched"></span><span class="act-name" title="${escH(it.title)}">${escH(it.title)}</span>${proj}<span class="act-meta">${escH(_actSchedWhen(it.scheduled_at))}${rec}</span></div>`;
+    // #27: a task waiting out an account usage limit sits in the same queue as a scheduled
+    // one; without this marker the wait reads as a start time the user picked.
+    const paused = it.paused_reason === 'usage_limit'
+      ? `<span class="act-meta act-paused" title="${escH(t('act.paused_tip'))}">⏸ ${escH(t('act.paused'))}</span>` : '';
+    return `<div class="act-item${staticCls}" ${onclick}><span class="act-dot sched"></span><span class="act-name" title="${escH(it.title)}">${escH(it.title)}</span>${proj}${paused}<span class="act-meta">${escH(_actSchedWhen(it.scheduled_at))}${rec}</span></div>`;
   }
   const ago = it.updated_at ? _actAgo(Date.now() - _actTs(it.updated_at)) : '';
   return `<div class="act-item" onclick="activityOpen('${it.session_id}','${it.project_id||''}')"><span class="act-dot recent"></span><span class="act-name" title="${escH(it.title)}">${escH(it.title)}</span>${proj}<span class="act-meta">${escH(ago)}</span></div>`;

--- a/public/kanban.html
+++ b/public/kanban.html
@@ -184,6 +184,7 @@ button:focus-visible,a:focus-visible{ border-radius:5px; }
 .badge-green{ background:rgba(63,185,80,.12); color:var(--green); border:1px solid rgba(63,185,80,.2); }
 .badge-orange{ background:rgba(229,164,53,.12); color:var(--orange); border:1px solid rgba(229,164,53,.2); }
 .badge-sched{ background:rgba(56,139,253,.1); color:#58a6ff; border:1px solid rgba(56,139,253,.22); display:inline-flex; align-items:center; gap:3px; cursor:default; }
+.badge-paused{ background:rgba(229,164,53,.12); color:var(--orange); border:1px solid rgba(229,164,53,.28); display:inline-flex; align-items:center; gap:3px; cursor:default; }
 .sched-info{ display:flex; align-items:center; gap:7px; background:rgba(56,139,253,.07); border:1px solid rgba(56,139,253,.2); color:#58a6ff; border-radius:6px; padding:8px 12px; font-size:12px; line-height:1.4; }
 .sched-info strong{ color:#79b8ff; font-weight:600; }
 .card-time{ font-size:11px; color:var(--muted); margin-left:auto; }
@@ -489,6 +490,7 @@ const TR = {
     'nav.chat':'Чат','nav.kanban':'Kanban дошка','nav.aria':'Навігація між розділами',
     'stat.total':'всього',
     'card.sched_tip':'Чекає запуску:','modal.sched_wait':'Чекає запуску:','locale':'uk-UA',
+    'card.paused':'Ліміт використання','card.paused_tip':'Виконання зупинив ліміт використання. Автопродовження:',
     'hdr.group':'Група','group.add':'Нова група','group.edit':'Редагувати групу',
     'group.title':'Назва групи *','group.tasks':'Завдання','group.add_task':'+ Додати завдання',
     'group.empty':'Додайте завдання до групи','group.activate':'Запустити',
@@ -531,6 +533,7 @@ const TR = {
     'nav.chat':'Chat','nav.kanban':'Kanban board','nav.aria':'Navigation',
     'stat.total':'total',
     'card.sched_tip':'Waiting for launch:','modal.sched_wait':'Waiting for launch:','locale':'en-US',
+    'card.paused':'Usage limit','card.paused_tip':'Stopped by a usage limit. Resumes automatically:',
     'hdr.group':'Group','group.add':'New group','group.edit':'Edit group',
     'group.title':'Group title *','group.tasks':'Tasks','group.add_task':'+ Add task',
     'group.empty':'Add tasks to the group','group.activate':'Run',
@@ -573,6 +576,7 @@ const TR = {
     'nav.chat':'Чат','nav.kanban':'Kanban доска','nav.aria':'Навигация',
     'stat.total':'всего',
     'card.sched_tip':'Ожидает запуска:','modal.sched_wait':'Ожидает запуска:','locale':'ru-RU',
+    'card.paused':'Лимит использования','card.paused_tip':'Выполнение остановил лимит использования. Автопродолжение:',
     'hdr.group':'Группа','group.add':'Новая группа','group.edit':'Редактировать группу',
     'group.title':'Название группы *','group.tasks':'Задания','group.add_task':'+ Добавить задание',
     'group.empty':'Добавьте задания в группу','group.activate':'Запустить',
@@ -1107,6 +1111,15 @@ async function onKbProjectChange(){
   }
 }
 
+// #27: failure_reason "usage_limit:<unix> <banner>" means the run was stopped by an account
+// usage limit and re-queued — the scheduler resumes it once the reset passes. Distinct from
+// 'usage_limit_exhausted' (pause budget spent), which lands in the cancelled column.
+function kbUsageLimit(tk){
+  if(!tk||tk.status!=='todo')return null;
+  const m=/^usage_limit(?::(\d+))?(?:\s+([\s\S]*))?$/.exec(tk.failure_reason||'');
+  if(!m)return null;
+  return {resumeAt:m[1]?+m[1]:(tk.scheduled_at||null),message:(m[2]||'').trim().substring(0,160)};
+}
 function makeCard(tk){
   const el=document.createElement('div');el.className='card';el.dataset.id=tk.id;el.draggable=true;
   let sessBadge='';
@@ -1117,7 +1130,9 @@ function makeCard(tk){
   }
   const modelBadge=tk.sess_model?`<span class="badge badge-muted">${escH(tk.sess_model)}</span>`:'';
   const retryBadge=tk.retry_count>0?`<span class="badge badge-muted" title="${tk.retry_count} ${t('card.retry_tooltip')}">${escH(t('card.retry'))} ×${tk.retry_count}</span>`:'';
-  const schedBadge=(tk.scheduled_at&&(tk.status==='todo'||tk.status==='backlog'))?`<span class="badge badge-sched" title="${escH(t('card.sched_tip'))} ${escH(fmtScheduledAt(tk.scheduled_at))}"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 12"/></svg>${escH(fmtScheduledAt(tk.scheduled_at))}</span>`:'';
+  const pausedInfo=kbUsageLimit(tk);
+  const pausedBadge=pausedInfo?`<span class="badge badge-paused" title="${escH(t('card.paused_tip'))} ${escH(pausedInfo.resumeAt?fmtScheduledAt(pausedInfo.resumeAt):'')}${pausedInfo.message?' — '+escH(pausedInfo.message):''}">⏸ ${escH(t('card.paused'))}${pausedInfo.resumeAt?' · '+escH(fmtScheduledAt(pausedInfo.resumeAt)):''}</span>`:'';
+  const schedBadge=(!pausedInfo&&tk.scheduled_at&&(tk.status==='todo'||tk.status==='backlog'))?`<span class="badge badge-sched" title="${escH(t('card.sched_tip'))} ${escH(fmtScheduledAt(tk.scheduled_at))}"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 12"/></svg>${escH(fmtScheduledAt(tk.scheduled_at))}</span>`:'';
   // Only while the board shows every project: inside one project the badge would repeat
   // the same name on every card and say nothing.
   const projBadge=(!curWorkdir&&tk.workdir)?`<span class="badge badge-proj" title="${escH(tk.workdir)}">${escH(projName(tk.workdir))}</span>`:'';
@@ -1125,7 +1140,7 @@ function makeCard(tk){
     <div class="card-title">${escH(tk.title)}</div>
     ${tk.description?`<div class="card-desc">${escH(tk.description)}</div>`:''}
     <div class="card-foot">
-      ${projBadge}${schedBadge}${sessBadge}${modelBadge}${retryBadge}
+      ${projBadge}${pausedBadge}${schedBadge}${sessBadge}${modelBadge}${retryBadge}
       <span class="card-time">${relTime(tk.updated_at)}</span>
       <span class="card-actions">
         <button class="cbtn" title="${t('modal.edit')}" onclick="event.stopPropagation();openEditModal('${tk.id}')">✎</button>

--- a/rate-limit-utils.js
+++ b/rate-limit-utils.js
@@ -54,4 +54,172 @@ function shouldRetryOverload({ texts = [], subtype, isError, rateLimitRejected =
   return overloaded && !cleanSuccess && !rateLimitRejected;
 }
 
-module.exports = { isTransientOverload, shouldRetryOverload, TRANSIENT_OVERLOAD_RE };
+// ─── Account usage-quota limits (case 1 above) ───────────────────────────────
+//
+// The CLI can end a turn with subtype:'success' while the visible output is nothing
+// but a quota banner, e.g.
+//   "You've hit your session limit · resets 11pm (Europe/Paris)"
+// The task worker used to read that as a completed task and moved the Kanban card to
+// Done (issue #27). These helpers give it a single, testable way to tell the two apart.
+//
+// The signatures below are deliberately DISJOINT from TRANSIENT_OVERLOAD_RE: the phrase
+// "not your usage limit" belongs to the transient throttle and must never be read as a
+// quota rejection, so the transient phrases are stripped from the text before matching.
+
+const TRANSIENT_OVERLOAD_RE_G = /temporarily limiting requests|not your usage limit|overloaded_error/gi;
+
+const USAGE_LIMIT_RE = new RegExp([
+  // Claude CLI banner — "You've hit your session limit", "You've reached your usage limit",
+  // "You have reached your weekly limit". Up to 3 words between "your" and "limit" keeps
+  // this anchored to the banner and off ordinary prose.
+  "you\\s*['’]?\\s*ve\\s+(?:hit|reached|used\\s+up)\\s+your\\s+(?:[\\w%-]+\\s+){0,3}limit",
+  "you\\s+have\\s+(?:hit|reached|used\\s+up)\\s+your\\s+(?:[\\w%-]+\\s+){0,3}limit",
+  // "Claude usage limit reached", "5-hour limit reached", "weekly limit reached"
+  "(?:usage|session|weekly|monthly|daily|hour|opus|sonnet|token|message)\\s+limit\\s+reached",
+  // Provider 429 / quota bodies
+  "rate\\s+limit\\s+exceeded",
+  "quota\\s+exceeded",
+  "exceeded\\s+your\\s+(?:current\\s+)?quota",
+  "insufficient_quota",
+  "usage_limit_reached",
+  "out\\s+of\\s+(?:credits|quota)",
+  "credit\\s+balance\\s+is\\s+too\\s+low",
+].join('|'), 'i');
+
+// "· resets 11pm (Europe/Paris)", "resets at 5pm", "resets 09:00 (UTC)".
+// A bare "resets 11" is rejected: without minutes or am/pm it is not a wall clock.
+const RESET_TIME_RE = /resets?(?:\s+at)?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\s*(?:\(([^)]{1,40})\))?/i;
+
+/** Strip the transient-throttle phrases so they can never satisfy USAGE_LIMIT_RE. */
+function withoutTransientPhrases(text) {
+  return String(text).replace(TRANSIENT_OVERLOAD_RE_G, ' ');
+}
+
+/**
+ * True when `text` carries an ACCOUNT usage-quota rejection (session / weekly / provider
+ * quota), as opposed to the transient server throttle owned by isTransientOverload().
+ * @param {string} text
+ * @returns {boolean}
+ */
+function isUsageLimit(text = '') {
+  if (!text || typeof text !== 'string') return false;
+  return USAGE_LIMIT_RE.test(withoutTransientPhrases(text));
+}
+
+/** Offset of `timeZone` from UTC at `atMs`, in ms; null when the zone is unknown. */
+function tzOffsetMs(timeZone, atMs) {
+  try {
+    const dtf = new Intl.DateTimeFormat('en-US', {
+      timeZone, hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    });
+    const p = {};
+    for (const part of dtf.formatToParts(new Date(atMs))) p[part.type] = part.value;
+    let h = Number(p.hour);
+    if (h === 24) h = 0; // some ICU builds render midnight as 24
+    const asUtc = Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day), h, Number(p.minute), Number(p.second));
+    return asUtc - atMs;
+  } catch { return null; }
+}
+
+/**
+ * Next occurrence of the wall clock hour:minute in `timeZone` (local time when the zone is
+ * absent or unknown), as unix seconds. The zone offset is sampled at `now`, so a reset that
+ * sits on the other side of a DST switch can be off by an hour — acceptable, because the
+ * worker only uses it to decide when to re-queue, and the scheduler re-checks every 15s.
+ */
+function nextWallClock(hour, minute, timeZone, now) {
+  const tzOff = timeZone ? tzOffsetMs(timeZone, now) : null;
+  const off = tzOff == null ? -new Date(now).getTimezoneOffset() * 60000 : tzOff;
+  const shifted = new Date(now + off); // read with getUTC* to see the target zone's wall clock
+  let target = Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate(), hour, minute, 0) - off;
+  if (target <= now) target += 86400000;
+  return Math.floor(target / 1000);
+}
+
+/**
+ * Parse "· resets 11pm (Europe/Paris)" out of a limit banner.
+ * @param {string} text
+ * @param {number} [now] - reference instant (ms), injectable for tests
+ * @returns {{raw:string, hour:number, minute:number, timeZone:string|null, epochSeconds:number}|null}
+ */
+function parseResetTime(text = '', now = Date.now()) {
+  if (!text || typeof text !== 'string') return null;
+  const m = RESET_TIME_RE.exec(text);
+  if (!m) return null;
+  if (!m[2] && !m[3]) return null; // neither minutes nor am/pm — not a wall clock
+  let hour = parseInt(m[1], 10);
+  const minute = m[2] ? parseInt(m[2], 10) : 0;
+  const ampm = m[3] ? m[3].toLowerCase() : null;
+  const timeZone = m[4] ? m[4].trim() : null;
+  if (!Number.isFinite(hour) || minute > 59) return null;
+  if (ampm) {
+    if (hour < 1 || hour > 12) return null;
+    if (ampm === 'pm' && hour !== 12) hour += 12;
+    if (ampm === 'am' && hour === 12) hour = 0;
+  } else if (hour > 23) return null;
+  return { raw: m[0], hour, minute, timeZone, epochSeconds: nextWallClock(hour, minute, timeZone, now) };
+}
+
+/** The single line that carries the limit banner, clipped for storage in failure_reason. */
+function usageLimitSnippet(text) {
+  const lines = String(text).split(/\r?\n/);
+  for (const line of lines) {
+    if (USAGE_LIMIT_RE.test(withoutTransientPhrases(line))) return line.trim().substring(0, 160);
+  }
+  return String(text).trim().substring(0, 160);
+}
+
+/**
+ * Inspect the texts of a finished turn for an account usage-limit stop.
+ * @param {object} o
+ * @param {string[]} [o.texts] - candidate texts (turn tail, result payload, error text)
+ * @param {number} [o.now] - reference instant (ms), injectable for tests
+ * @returns {{reason:'usage_limit', message:string, resetAt:number|null, timeZone:string|null}|null}
+ */
+function detectUsageLimit({ texts = [], now = Date.now() } = {}) {
+  for (const raw of texts) {
+    if (!isUsageLimit(raw)) continue;
+    const snippet = usageLimitSnippet(raw);
+    // Prefer the reset time on the banner line; fall back to the 200 chars that follow it.
+    const idx = withoutTransientPhrases(raw).search(USAGE_LIMIT_RE);
+    const window = idx >= 0 ? String(raw).substring(idx, idx + 200) : '';
+    const reset = parseResetTime(snippet, now) || parseResetTime(window, now);
+    return {
+      reason: 'usage_limit',
+      message: snippet,
+      resetAt: reset ? reset.epochSeconds : null,
+      timeZone: reset ? reset.timeZone : null,
+    };
+  }
+  return null;
+}
+
+/**
+ * Terminal Kanban status for a finished task turn — the single source of truth behind the
+ * #27 fix. A usage-limit stop returns 'paused' even when the CLI reported subtype 'success',
+ * because the banner IS the whole output of that "successful" turn.
+ *
+ * 'paused' is written to the DB as status='todo' + scheduled_at=<reset>, which is what makes
+ * the existing scheduler re-run the task by itself once the quota is back.
+ *
+ * @param {object} o
+ * @param {string[]} [o.texts]
+ * @param {string} [o.subtype] - result subtype
+ * @param {boolean} [o.isError] - the turn raised an error
+ * @param {boolean} [o.wasStopped] - the user stopped the task
+ * @param {number} [o.now]
+ * @returns {'cancelled'|'paused'|'done'|'failed'}
+ */
+function taskStatusForStop({ texts = [], subtype, isError = false, wasStopped = false, now = Date.now() } = {}) {
+  if (wasStopped) return 'cancelled';
+  if (detectUsageLimit({ texts, now })) return 'paused';
+  return (subtype === 'success' && !isError) ? 'done' : 'failed';
+}
+
+module.exports = {
+  isTransientOverload, shouldRetryOverload, TRANSIENT_OVERLOAD_RE,
+  isUsageLimit, parseResetTime, detectUsageLimit, taskStatusForStop, usageLimitSnippet,
+  USAGE_LIMIT_RE, RESET_TIME_RE,
+};

--- a/server.js
+++ b/server.js
@@ -36,7 +36,7 @@ const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const auth = require('./auth');
 const ClaudeCLI = require('./claude-cli');
-const { isTransientOverload, shouldRetryOverload } = require('./rate-limit-utils');
+const { isTransientOverload, shouldRetryOverload, detectUsageLimit, taskStatusForStop } = require('./rate-limit-utils');
 const { buildTerminalCommand: buildDelegateCommand, winTerminalArgs } = require('./delegate-terminal');
 const { isAgentSuccess, shouldAutoContinue, agentStopReason } = require('./multi-agent-result');
 const {
@@ -507,6 +507,8 @@ try { db.exec(`ALTER TABLE tasks ADD COLUMN chain_id TEXT`); } catch {}
 try { db.exec(`ALTER TABLE tasks ADD COLUMN source_session_id TEXT`); } catch {}
 try { db.exec(`ALTER TABLE tasks ADD COLUMN failure_reason TEXT`); } catch {}
 try { db.exec(`ALTER TABLE tasks ADD COLUMN task_retry_count INTEGER DEFAULT 0`); } catch {}
+// #27: how many times this task was paused by an account usage limit (bounded auto-resume)
+try { db.exec(`ALTER TABLE tasks ADD COLUMN usage_limit_pauses INTEGER DEFAULT 0`); } catch {}
 // Scheduled tasks: time-based triggers + recurring runs
 try { db.exec(`ALTER TABLE tasks ADD COLUMN scheduled_at INTEGER`); } catch {}
 try { db.exec(`ALTER TABLE tasks ADD COLUMN recurrence TEXT`); } catch {}
@@ -1586,16 +1588,56 @@ async function startTask(task) {
       const wasStopped = stoppingTasks.has(task.id);
       stoppingTasks.delete(task.id);
       if (!wasStopped) {
-        const isSuccess = lastTaskResult?.subtype === 'success' && !hasError;
+        // ⏸ #27 — an account quota banner ("You've hit your session limit · resets 11pm
+        // (Europe/Paris)") ends the turn with subtype:'success', so the old
+        // `subtype === 'success'` check marked an interrupted task Done. taskStatusForStop()
+        // in rate-limit-utils.js owns that decision now. Only the TAIL of the run is scanned:
+        // the banner is the last thing the CLI emits, whereas an agent that merely *discusses*
+        // rate limits does so mid-run.
+        const _resultText = typeof lastTaskResult?.result === 'string' ? lastTaskResult.result : '';
+        const _stopTexts = [fullText.slice(-USAGE_LIMIT_TAIL_CHARS), _resultText];
+        const _stopStatus = taskStatusForStop({ texts: _stopTexts, subtype: lastTaskResult?.subtype, isError: hasError });
+        const _pausesSoFar = task.usage_limit_pauses || 0;
+        const usageLimit = (_stopStatus === 'paused' && _pausesSoFar < MAX_USAGE_LIMIT_PAUSES)
+          ? detectUsageLimit({ texts: _stopTexts })
+          : null;
+        // Pause budget spent: stop re-queuing, fail with a reason that names the cause.
+        const usageLimitExhausted = _stopStatus === 'paused' && !usageLimit;
+        const isSuccess = _stopStatus === 'done';
         const isRateLimited = isTransientOverload(fullText)
           || (hasError && (fullText.includes('rate_limit') || fullText.includes('overloaded') || fullText.includes('Too many')));
         const MAX_CHAIN_RETRIES = 2;
 
-        if (isSuccess) {
+        if (usageLimit) {
+          // Re-queue instead of completing: getTodoTasks() skips a todo row until its
+          // scheduled_at passes, and processQueue() (15s tick) starts it right after — the
+          // same machinery recurring tasks use. session_id is kept, so the run resumes the
+          // same Claude session via --resume.
+          const _nowSec = Math.floor(Date.now() / 1000);
+          const resumeAt = (usageLimit.resetAt && usageLimit.resetAt > _nowSec)
+            ? usageLimit.resetAt
+            : _nowSec + USAGE_LIMIT_FALLBACK_WAIT_S;
+          // Format: "usage_limit:<unix> <banner>" — public/kanban.html parses the prefix.
+          const reason = `usage_limit:${resumeAt} ${usageLimit.message || ''}`.trim().substring(0, 300);
+          db.prepare(`UPDATE tasks SET status='todo', scheduled_at=?, failure_reason=?, usage_limit_pauses=COALESCE(usage_limit_pauses,0)+1, worker_pid=NULL, updated_at=datetime('now') WHERE id=?`)
+            .run(resumeAt, reason, task.id);
+          log.warn(`[taskWorker] task ${task.id}: usage limit — paused, resuming ${new Date(resumeAt * 1000).toISOString()} (${_pausesSoFar + 1}/${MAX_USAGE_LIMIT_PAUSES})`);
+          if (task.source_session_id) {
+            const _ctx = getNotificationContext(task.source_session_id);
+            broadcastToSession(task.source_session_id, {
+              type: 'notification', level: 'warn',
+              title: `Paused: "${task.title}"`,
+              detail: `Usage limit. Resuming ${new Date(resumeAt * 1000).toLocaleString()}.`,
+              tabId: task.source_session_id,
+              chainTaskId: task.id, chainStatus: 'paused',
+              sessionTitle: _ctx.sessionTitle, projectName: _ctx.projectName,
+            });
+          }
+        } else if (isSuccess) {
           // ✅ Success — recurring standalone tasks re-arm directly (skip intermediate 'done')
           const reArmed = (task.recurrence && !task.chain_id) ? scheduleNextRun(task) : false;
           if (!reArmed) {
-            db.prepare(`UPDATE tasks SET status='done', failure_reason=NULL, worker_pid=NULL, updated_at=datetime('now') WHERE id=?`)
+            db.prepare(`UPDATE tasks SET status='done', failure_reason=NULL, usage_limit_pauses=0, worker_pid=NULL, updated_at=datetime('now') WHERE id=?`)
               .run(task.id);
           }
           db.prepare(`UPDATE sessions SET retry_count=0 WHERE id=?`).run(sessionId);
@@ -1628,7 +1670,7 @@ async function startTask(task) {
               duration: Date.now() - _taskStartedAt,
             }).catch(() => {});
           }
-        } else if (task.chain_id && (task.task_retry_count || 0) < MAX_CHAIN_RETRIES) {
+        } else if (task.chain_id && !usageLimitExhausted && (task.task_retry_count || 0) < MAX_CHAIN_RETRIES) {
           // 🔄 Auto-retry for chain tasks — don't give up on first failure
           const reason = isRateLimited ? 'rate_limited' : 'agent_incomplete';
           _retryBackoffMs = isRateLimited ? Math.min(60000 * ((task.task_retry_count || 0) + 1), 300000) : 3000;
@@ -1648,7 +1690,7 @@ async function startTask(task) {
           }
         } else {
           // ❌ Failed — retries exhausted or not a chain task
-          const reason = isRateLimited ? 'rate_limited' : 'agent_incomplete';
+          const reason = usageLimitExhausted ? 'usage_limit_exhausted' : isRateLimited ? 'rate_limited' : 'agent_incomplete';
           db.prepare(`UPDATE tasks SET status='cancelled', failure_reason=?, worker_pid=NULL, updated_at=datetime('now') WHERE id=?`)
             .run(reason, task.id);
           log.error(`[taskWorker] task ${task.id}: cancelled (${reason}, subtype: ${lastTaskResult?.subtype || 'unknown'})`);
@@ -2881,6 +2923,12 @@ const MAX_OVERLOAD_RETRIES = 5;
 const OVERLOAD_BACKOFF_BASE_MS = 20 * 1000; // 20s — first pause
 const OVERLOAD_BACKOFF_STEP_MS = 10 * 1000; // +10s per subsequent attempt
 const OVERLOAD_BACKOFF_MAX_MS = 60 * 1000;  // cap at 60s
+// Account usage-quota limit (#27) — "You've hit your session limit · resets 11pm (Europe/Paris)".
+// The turn is NOT a completed task: the card is re-queued (status='todo') at the reset time and
+// the ordinary 15s scheduler tick resumes it. Bounded, so a misparsed reset cannot loop forever.
+const MAX_USAGE_LIMIT_PAUSES = 8;
+const USAGE_LIMIT_FALLBACK_WAIT_S = 30 * 60; // 30 min when the banner carries no reset time
+const USAGE_LIMIT_TAIL_CHARS = 2000;         // only the tail of a run can hold the stop banner
 
 // Sleep that resolves on timeout or when signal fires (whichever first)
 function _sleepAbortable(ms, signal) {
@@ -5077,13 +5125,16 @@ app.get('/api/activity', (req, res) => {
     }
 
     // 3) Scheduled (upcoming) todo tasks.
-    const sched = db.prepare(`SELECT id,title,session_id,workdir,scheduled_at,recurrence FROM tasks WHERE status='todo' AND scheduled_at IS NOT NULL ORDER BY scheduled_at ASC LIMIT 50`).all();
+    const sched = db.prepare(`SELECT id,title,session_id,workdir,scheduled_at,recurrence,failure_reason FROM tasks WHERE status='todo' AND scheduled_at IS NOT NULL ORDER BY scheduled_at ASC LIMIT 50`).all();
     const scheduled = sched.map(tsk => ({
       task_id: tsk.id,
       session_id: tsk.session_id || null,
       title: tsk.title || 'Task',
       scheduled_at: tsk.scheduled_at, // unix seconds
       recurrence: tsk.recurrence || null,
+      // #27: a task waiting out an account usage limit is queued, not merely scheduled —
+      // the client marks it so the wait does not read as a user-chosen start time.
+      paused_reason: /^usage_limit\b/.test(tsk.failure_reason || '') ? 'usage_limit' : null,
       ...resolveProj(tsk.workdir),
     }));
 

--- a/test/usage-limit.test.js
+++ b/test/usage-limit.test.js
@@ -1,0 +1,144 @@
+// Issue #27 — an account usage limit must not finish a task as "Done".
+//
+// The CLI ends a quota-stopped turn with subtype:'success' and a banner as its whole
+// output ("You've hit your session limit · resets 11pm (Europe/Paris)"), so the task
+// worker's old `subtype === 'success' && !hasError` check moved the Kanban card to Done
+// while the work was unfinished. rate-limit-utils.js now owns that decision.
+//
+// The other half of the contract: these detectors must stay DISJOINT from the transient
+// server-overload detector (isTransientOverload) — "Server is temporarily limiting
+// requests (not your usage limit)" is a 20s backoff, not a quota rejection, and the
+// phrase "not your usage limit" literally contains "usage limit".
+//
+// Run: node test/usage-limit.test.js
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const {
+  isUsageLimit, isTransientOverload, parseResetTime, detectUsageLimit, taskStatusForStop,
+} = require('../rate-limit-utils');
+
+let pass = 0, fail = 0;
+function check(label, actual, expected) {
+  try { assert.deepStrictEqual(actual, expected); pass++; console.log(`  ok   ${label}`); }
+  catch { fail++; console.error(`  FAIL ${label} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`); }
+}
+
+const SESSION_LIMIT = "You've hit your session limit · resets 11pm (Europe/Paris)";
+const TRANSIENT = 'API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited';
+
+// ── 1. Detection positives ──────────────────────────────────────────────────
+console.log('isUsageLimit — the messages named in the issue:');
+check('session limit banner (verbatim from the issue)', isUsageLimit(SESSION_LIMIT), true);
+check("You've hit your session limit", isUsageLimit("You've hit your session limit"), true);
+check("You've reached your usage limit", isUsageLimit("You've reached your usage limit"), true);
+check('Rate limit exceeded', isUsageLimit('Rate limit exceeded'), true);
+check('case-insensitive', isUsageLimit("YOU'VE HIT YOUR SESSION LIMIT"), true);
+check('curly apostrophe', isUsageLimit('You’ve reached your usage limit'), true);
+check('you have reached your weekly limit', isUsageLimit('You have reached your weekly limit'), true);
+check('Claude usage limit reached', isUsageLimit('Claude usage limit reached|1755808800'), true);
+check('5-hour limit reached', isUsageLimit('Your 5-hour limit reached, try later'), true);
+check('provider quota exceeded', isUsageLimit('429 You exceeded your current quota, please check your plan'), true);
+check('provider insufficient_quota', isUsageLimit('{"error":{"code":"insufficient_quota"}}'), true);
+check('provider quota exceeded (bare)', isUsageLimit('Quota exceeded for quota metric'), true);
+check('credit balance too low', isUsageLimit('Your credit balance is too low to access the API'), true);
+check('embedded mid-text', isUsageLimit("Wrote the file.\n\nYou've hit your session limit · resets 11pm (Europe/Paris)\n"), true);
+
+// ── 2. Detection negatives — the transient overload stays with its own detector ──
+console.log('\nisUsageLimit — must NOT claim the transient-overload strings:');
+check('reported transient error string', isUsageLimit(TRANSIENT), false);
+check('temporarily limiting requests', isUsageLimit('Server is temporarily limiting requests, retry.'), false);
+check('not-your-usage-limit phrase', isUsageLimit('transient (not your usage limit).'), false);
+check('overloaded_error api type', isUsageLimit('{"error":{"type":"overloaded_error"}}'), false);
+check('the transient detector still owns that string', isTransientOverload(TRANSIENT), true);
+check('the quota detector and the overload detector never both fire',
+  [SESSION_LIMIT, TRANSIENT].map(x => `${isUsageLimit(x)}/${isTransientOverload(x)}`),
+  ['true/false', 'false/true']);
+
+console.log('\nisUsageLimit — false-positive guards:');
+check('agent prose about implementing rate limiting', isUsageLimit("I'll add rate limiting returning 429."), false);
+check('agent prose about a quota field', isUsageLimit('The quota column is nullable.'), false);
+check('prose that merely says limit', isUsageLimit('There is no limit on the number of retries.'), false);
+check('empty', isUsageLimit(''), false);
+check('null', isUsageLimit(null), false);
+check('non-string', isUsageLimit(12345), false);
+
+// ── 3. Reset-time parsing ───────────────────────────────────────────────────
+// Fixed reference instant so the assertions do not drift with the wall clock:
+// 2026-08-21T12:00:00Z = 14:00 in Europe/Paris (CEST, UTC+2).
+console.log('\nparseResetTime — "· resets 11pm (Europe/Paris)":');
+const NOW = Date.UTC(2026, 7, 21, 12, 0, 0);
+const r = parseResetTime(SESSION_LIMIT, NOW);
+check('parses the banner', !!r, true);
+check('hour normalised to 24h', r && r.hour, 23);
+check('minute defaults to 0', r && r.minute, 0);
+check('timezone captured', r && r.timeZone, 'Europe/Paris');
+check('23:00 Paris today = 21:00Z today', r && r.epochSeconds, Date.UTC(2026, 7, 21, 21, 0, 0) / 1000);
+const rPast = parseResetTime('resets 11am (Europe/Paris)', NOW);
+check('a reset already past today rolls to tomorrow',
+  rPast && rPast.epochSeconds, Date.UTC(2026, 7, 22, 9, 0, 0) / 1000);
+const rUtc = parseResetTime('resets at 09:00 (UTC)', NOW);
+check('explicit minutes + UTC zone', rUtc && rUtc.epochSeconds, Date.UTC(2026, 7, 22, 9, 0, 0) / 1000);
+check('unknown zone still yields a future instant',
+  parseResetTime('resets 11pm (Mars/Olympus)', NOW).epochSeconds > NOW / 1000, true);
+check('no reset clause → null', parseResetTime("You've hit your session limit", NOW), null);
+check('vague "resets soon" → null', parseResetTime('resets soon', NOW), null);
+check('bare "resets 11" is not a wall clock → null', parseResetTime('resets 11', NOW), null);
+check('impossible hour → null', parseResetTime('resets 25:00 (UTC)', NOW), null);
+
+console.log('\ndetectUsageLimit — reason recorded for the paused task:');
+const det = detectUsageLimit({ texts: ['...work...\n' + SESSION_LIMIT], now: NOW });
+check('reason', det && det.reason, 'usage_limit');
+check('message is the banner line', det && det.message, SESSION_LIMIT);
+check('resetAt', det && det.resetAt, Date.UTC(2026, 7, 21, 21, 0, 0) / 1000);
+check('timeZone', det && det.timeZone, 'Europe/Paris');
+check('no reset time in the banner → resetAt null (caller falls back)',
+  detectUsageLimit({ texts: ['Rate limit exceeded'], now: NOW }).resetAt, null);
+check('clean run → null', detectUsageLimit({ texts: ['All tests pass.'], now: NOW }), null);
+check('transient overload → null (handled by the retry path)',
+  detectUsageLimit({ texts: [TRANSIENT], now: NOW }), null);
+
+// ── 4. The task-status decision — the actual bug ────────────────────────────
+console.log('\ntaskStatusForStop — a usage-limit stop must never be "done":');
+check('THE BUG: quota banner + subtype success → paused, not done',
+  taskStatusForStop({ texts: [SESSION_LIMIT], subtype: 'success', isError: false, now: NOW }), 'paused');
+check('quota banner + error subtype → paused',
+  taskStatusForStop({ texts: [SESSION_LIMIT], subtype: 'error_during_execution', isError: true, now: NOW }), 'paused');
+check('quota banner only in the result payload → paused',
+  taskStatusForStop({ texts: ['', 'Rate limit exceeded'], subtype: 'success', isError: false, now: NOW }), 'paused');
+check('genuine success → done',
+  taskStatusForStop({ texts: ['Task finished, tests green.'], subtype: 'success', isError: false, now: NOW }), 'done');
+check('success flagged with an error → failed',
+  taskStatusForStop({ texts: ['partial'], subtype: 'success', isError: true, now: NOW }), 'failed');
+check('max-turns stop → failed',
+  taskStatusForStop({ texts: ['partial'], subtype: 'error_max_turns', isError: false, now: NOW }), 'failed');
+check('transient overload + success → done (its own retry path already ran)',
+  taskStatusForStop({ texts: [TRANSIENT], subtype: 'success', isError: false, now: NOW }), 'done');
+check('user stop wins over everything',
+  taskStatusForStop({ texts: [SESSION_LIMIT], subtype: 'success', wasStopped: true, now: NOW }), 'cancelled');
+check('no args → failed (defensive, never done)', taskStatusForStop(), 'failed');
+
+// ── 5. Wiring — the worker must actually use the decision ───────────────────
+// A unit-green detector wired to nothing would still ship the bug, and the worker's
+// completion path is not reachable from a plain-node test without a live CLI run.
+console.log('\nserver.js wiring:');
+{
+  const src = fs.readFileSync(path.join(__dirname, '..', 'server.js'), 'utf8');
+  check('imports the decision helpers', /require\('\.\/rate-limit-utils'\)/.test(src)
+    && src.includes('detectUsageLimit') && src.includes('taskStatusForStop'), true);
+  check('the worker derives isSuccess from taskStatusForStop',
+    /const _stopStatus = taskStatusForStop\(/.test(src) && src.includes("const isSuccess = _stopStatus === 'done';"), true);
+  check('no bare subtype-success completion check remains in the worker',
+    src.includes("const isSuccess = lastTaskResult?.subtype === 'success' && !hasError;"), false);
+  check('a usage-limit stop re-queues (status=todo + scheduled_at) instead of done',
+    /UPDATE tasks SET status='todo', scheduled_at=\?, failure_reason=\?, usage_limit_pauses=/.test(src), true);
+  check('failure_reason carries the parseable usage_limit prefix',
+    src.includes('`usage_limit:${resumeAt}'), true);
+  check('the pause column is added by a guarded ALTER TABLE',
+    /try \{ db\.exec\(`ALTER TABLE tasks ADD COLUMN usage_limit_pauses INTEGER DEFAULT 0`\); \} catch \{\}/.test(src), true);
+  check('auto-resume rides the existing scheduler (todo rows gated on scheduled_at)',
+    src.includes("SELECT * FROM tasks WHERE status='todo' AND (scheduled_at IS NULL OR scheduled_at <= unixepoch())"), true);
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
Closes #27.

The reported bug is one line. The task worker derived completion from the CLI's own subtype:

```js
const isSuccess = lastTaskResult?.subtype === 'success' && !hasError;
```

A run that stops on `You've hit your session limit · resets 11pm (Europe/Paris)` exits with subtype `success`, so the card went to **Done** having done nothing.

**Detection** lives in `rate-limit-utils.js` as pure, unit-testable helpers (`isUsageLimit`, `parseResetTime`, `detectUsageLimit`, `taskStatusForStop`), next to the existing `isTransientOverload`/`shouldRetryOverload`. Keeping the two apart was the delicate part: the transient-overload banner literally reads *"Server is temporarily limiting requests (**not your usage limit**)"*, so the transient phrases are stripped before the quota test runs. Prose is guarded against too — `"I'll add rate limiting returning 429."` and `"The quota column is nullable."` do not match — and only the **last 2000 chars** of the turn are scanned, so an agent that merely discusses rate limits mid-run is never paused.

Matched: `you've/you have (hit|reached|used up) your … limit`, `(usage|session|weekly|monthly|daily|hourly|opus|sonnet|token|message) limit reached`, `rate limit exceeded`, `quota exceeded`, `exceeded your current quota`, `insufficient_quota`, `usage_limit_reached`, `out of credits/quota`, `credit balance is too low`.

`parseResetTime` reads `· resets 11pm (Europe/Paris)`, `resets at 5pm`, `resets 09:00 (UTC)`, converting the IANA zone through `Intl.DateTimeFormat` offset sampling; it rejects `resets 11`, `resets soon`, `resets 25:00`, and falls back to host-local for an unknown zone.

**Auto-resume** reuses the scheduler rather than adding a parallel one. A paused task is written as `status='todo'` with `scheduled_at = <reset>` — exactly the "queued, not yet runnable" state `getTodoTasks` already filters on (`status='todo' AND (scheduled_at IS NULL OR scheduled_at <= unixepoch())`), ticked every 15 s by `processQueue`. `session_id`/`claude_session_id` survive, so the resumed run takes the `isRetry` path and continues the same Claude session via `--resume` instead of starting over. Verified end to end against a throwaway DB: not picked up before the reset, picked up after it.

The reason is recorded in `failure_reason` as `usage_limit:<unix> <verbatim banner>`, and a new guarded `ALTER TABLE tasks ADD COLUMN usage_limit_pauses INTEGER DEFAULT 0` caps the loop at 8 pauses before the task lands in cancelled as `usage_limit_exhausted`.

**UI** — a `⏸ <label> · <reset time>` badge on the Kanban card with the banner in the tooltip (the ordinary schedule badge is suppressed so the time is not printed twice), plus a paused marker in the activity panel. Every new string is a translation key in **all** dictionaries of both `public/index.html` and `public/kanban.html`.

**Mutation evidence** — three separate mutations, each caught by name:

```
FAIL THE BUG: quota banner + subtype success → paused, not done — expected "paused", got "done"
FAIL session limit banner (verbatim from the issue) — expected true, got false
FAIL no bare subtype-success completion check remains in the worker — expected false, got true
```

`test/usage-limit.test.js` (new, in the `npm test` chain) is `61 passed, 0 failed`. Full suite after rebase: EXIT=0, zero FAIL lines.

Deliberate choices worth flagging: the issue offered *"In Progress (or Paused)"* — neither works as a resumable state here. `in_progress` is claimed by a live worker and gets reaped by the watchdog, and a brand-new `paused` value would be invisible to `processQueue`. `todo` + future `scheduled_at` + a distinct badge gives the correct semantics without teaching the scheduler a new state. One known cost: for a **recurring** task the pause overwrites `scheduled_at`, so the following occurrence is computed from the reset time rather than the original slot — a one-off drift per limit hit; removing it needs a separate `paused_until` column, which is heavier than the problem.

Also included: `CLAUDE.md` test counts corrected to the measured 30 (10 render + 20 node) — they had drifted two files behind.