### PR TITLE
fix: worktree isolation — inheritance, Telegram coverage, and safe worktree removal

### DIFF
--- a/server.js
+++ b/server.js
@@ -8090,6 +8090,20 @@ app.post('/api/sessions/bulk-delete', (req,res) => {
     try { termBridge.killSession(tmuxNameFor(id)); } catch {}
     try { fs.unlinkSync(path.join(os.tmpdir(), `ccsterm-sb-${id}.txt`)); } catch {}
   }
+  const del = db.transaction(() => {
+    for (const id of ids) {
+      // Unlink recurring tasks from session (preserve the schedule), delete the rest
+      db.prepare(`UPDATE tasks SET session_id=NULL WHERE session_id=? AND recurrence IS NOT NULL`).run(id);
+      stmts.deleteTasksBySession.run(id); stmts.deleteSession.run(id); sessionQueues.delete(id);
+      try { stmts.delQueuedBySession.run(id); } catch {}
+    }
+  });
+  del();
+  // Runs AFTER the cascade above, for the same reason the single delete does: read
+  // before it, the count still sees the task rows the cascade is about to remove and
+  // keeps a tree nobody owns a moment later. Recurring tasks are UNLINKED rather than
+  // deleted there, so they still count — correctly: their auto-merge is skipped and
+  // that tree is their live cwd.
   // Never a bare rm -rf — always through git so .git/worktrees/<name> never goes stale.
   //
   // Excluding only the row being processed is wrong for a BATCH: delete an origin and
@@ -8110,15 +8124,7 @@ app.post('/api/sessions/bulk-delete', (req,res) => {
       }
     }
   }
-  const del = db.transaction(() => {
-    for (const id of ids) {
-      // Unlink recurring tasks from session (preserve the schedule), delete the rest
-      db.prepare(`UPDATE tasks SET session_id=NULL WHERE session_id=? AND recurrence IS NOT NULL`).run(id);
-      stmts.deleteTasksBySession.run(id); stmts.deleteSession.run(id); sessionQueues.delete(id);
-      try { stmts.delQueuedBySession.run(id); } catch {}
-    }
-  });
-  del();
+
   res.json({ ok: true, deleted: ids.length });
 });
 app.get('/api/sessions/:id/git-status', (req, res) => {

--- a/server.js
+++ b/server.js
@@ -3481,6 +3481,26 @@ function setupUnitWorktree(kind, unitId, requestedWorkdir) {
   }
 }
 
+/** Worktree isolation for units Telegram creates with direct SQL.
+ *
+ *  telegram-bot.js does not require server.js — it takes its dependencies through the
+ *  constructor, the way getRoster already does — so the policy is injected rather than
+ *  imported, and stays defined in one place. Without it a Telegram chat writes into
+ *  the project root while a browser chat in the same project writes into its own
+ *  worktree, and the browser's merge lands on top of Telegram's uncommitted work.
+ *
+ *  Returns null when the unit is not isolatable (no workdir, a remote project, git
+ *  unavailable); the caller treats that as "stay in the project root", which is the
+ *  behaviour that predates isolation.
+ */
+function _isolateTelegramUnit(kind, unitId, workdir) {
+  const wt = setupUnitWorktree(kind, unitId, workdir);
+  if (!wt) return null;
+  if (kind === 'task') stmts.setTaskGit.run(wt.workdir, wt.git_root, wt.git_branch, unitId);
+  else stmts.setSessionGit.run(wt.workdir, wt.git_root, wt.git_branch, unitId);
+  return wt;
+}
+
 /**
  * Branch-status for the chat UI chip. green/amber/red from git state; purple
  * (merge conflict) overlays the stored git_conflict flag — a conflict happens
@@ -5454,13 +5474,26 @@ app.post('/api/internal/task-manager', express.json({ limit: '1mb' }), (req, res
         const contextJson = context ? (typeof context === 'string' ? context : JSON.stringify(context)).substring(0, 10000) : null;
         const depsJson = depends_on ? JSON.stringify(depends_on) : null;
 
+        // An MCP-created task is a live writer, exactly like one created through
+        // POST /api/tasks — so it gets its OWN worktree from the project root rather
+        // than running in whatever tree the caller happens to occupy. Without this it
+        // shared the caller's working copy and branch, which is the state isolation
+        // exists to prevent. GIT_UNAVAILABLE is reported rather than thrown: this is
+        // an MCP tool call, and a bare throw here answers the model with a stack.
+        let _mwt = null;
+        try { _mwt = setupUnitWorktree('task', id, workdir); }
+        catch (e) {
+          if (e.code === 'GIT_UNAVAILABLE') return res.json({ ok: false, error: e.message });
+          throw e;
+        }
+
         stmts.createTask.run(
           id, String(title).substring(0, 200), String(description).substring(0, 2000),
           '', // notes
           'todo', // status — immediately eligible for processQueue
           0,  // sort_order
           (chain_id ? callerTask?.session_id : null) || null, // session_id — only inherit for chain tasks
-          workdir,
+          _mwt ? _mwt.workdir : workdir,
           model || callerTask?.model || 'sonnet',
           mode || callerTask?.mode || 'auto',
           agent_mode || callerTask?.agent_mode || 'single',
@@ -5477,6 +5510,7 @@ app.post('/api/internal/task-manager', express.json({ limit: '1mb' }), (req, res
         ,
           botsLogic.inheritBotId(callerTask)  // bot_id: a bot's subtask stays that bot's
         );
+        if (_mwt) stmts.setTaskGit.run(_mwt.workdir, _mwt.git_root, _mwt.git_branch, id);
 
         // Set new columns that aren't in createTask prepared statement
         stmts.setTaskContext.run(contextJson, callerTaskId || null, id);
@@ -9740,7 +9774,7 @@ function initTelegramBot() {
   const tg = c.telegram;
   if (!tg || !tg.enabled || !tg.botToken) return;
 
-  telegramBot = new TelegramBot(db, { log, lang: c.lang || 'uk', getRoster: telegramRoster });
+  telegramBot = new TelegramBot(db, { log, lang: c.lang || 'uk', getRoster: telegramRoster, isolateUnit: _isolateTelegramUnit });
   telegramBot.acceptNewConnections = tg.acceptNewConnections !== false;
   _attachTelegramListeners(telegramBot);
 
@@ -9784,7 +9818,7 @@ app.post('/api/telegram/start', (req, res) => {
   }
 
   // Start new bot
-  telegramBot = new TelegramBot(db, { log, lang: c.lang || 'uk', getRoster: telegramRoster });
+  telegramBot = new TelegramBot(db, { log, lang: c.lang || 'uk', getRoster: telegramRoster, isolateUnit: _isolateTelegramUnit });
   telegramBot.acceptNewConnections = c.telegram.acceptNewConnections !== false;
   _attachTelegramListeners(telegramBot);
 

--- a/server.js
+++ b/server.js
@@ -3481,6 +3481,27 @@ function setupUnitWorktree(kind, unitId, requestedWorkdir) {
   }
 }
 
+/** Is this worktree still someone else's working directory?
+ *
+ *  A worktree is shared more often than it looks: a compact continues its origin's
+ *  tree, and startTask()'s sidecar session runs in the TASK's tree. Removing it
+ *  because one holder was deleted strands the others — and `force: true` means that
+ *  removal reports no error at all, so the check has to happen before the call.
+ *
+ *  Both tables are counted. Counting only `sessions` missed the case that actually
+ *  destroys work: a recurring task SURVIVES the deletion of its session (the row is
+ *  unlinked, not deleted) and its auto-merge is deliberately skipped, so that
+ *  worktree is its live cwd.
+ */
+function _worktreeStillInUse(workdir, { exceptSession = null, exceptTask = null } = {}) {
+  if (!workdir) return false;
+  try {
+    const s = db.prepare(`SELECT COUNT(*) c FROM sessions WHERE workdir=? AND id<>COALESCE(?, '')`).get(workdir, exceptSession).c;
+    const t = db.prepare(`SELECT COUNT(*) c FROM tasks    WHERE workdir=? AND id<>COALESCE(?, '')`).get(workdir, exceptTask).c;
+    return (s + t) > 0;
+  } catch { return false; }
+}
+
 /** Worktree isolation for units Telegram creates with direct SQL.
  *
  *  telegram-bot.js does not require server.js — it takes its dependencies through the
@@ -5470,22 +5491,19 @@ app.post('/api/internal/task-manager', express.json({ limit: '1mb' }), (req, res
         const callerTask = callerTaskId ? stmts.getTask.get(callerTaskId) : null;
         const workdir = callerTask?.git_root || callerTask?.workdir || null;
 
+        // NOT isolated, and that is a decision rather than an omission. Minting a
+        // worktree here writes git_root/git_branch onto the row, and those two columns
+        // are what ARM the auto-merge in startTask (server.js ~2137) — which never ran
+        // for MCP children before, because they were NULL. A unique worktree also walks
+        // straight past the chain workdir lock (~2449), so a chain created through MCP
+        // would start its members in parallel while auto-merge writes into git_root
+        // underneath them. And `get_task_result`/`cancel_task` still compare a RAW
+        // workdir (~5711) where `list_tasks` already uses COALESCE(git_root, workdir),
+        // so a parent would get 403 on the result of the task it just created.
+        // This belongs to the chain bundle, which moves as one piece or not at all.
         const id = genId();
         const contextJson = context ? (typeof context === 'string' ? context : JSON.stringify(context)).substring(0, 10000) : null;
         const depsJson = depends_on ? JSON.stringify(depends_on) : null;
-
-        // An MCP-created task is a live writer, exactly like one created through
-        // POST /api/tasks — so it gets its OWN worktree from the project root rather
-        // than running in whatever tree the caller happens to occupy. Without this it
-        // shared the caller's working copy and branch, which is the state isolation
-        // exists to prevent. GIT_UNAVAILABLE is reported rather than thrown: this is
-        // an MCP tool call, and a bare throw here answers the model with a stack.
-        let _mwt = null;
-        try { _mwt = setupUnitWorktree('task', id, workdir); }
-        catch (e) {
-          if (e.code === 'GIT_UNAVAILABLE') return res.json({ ok: false, error: e.message });
-          throw e;
-        }
 
         stmts.createTask.run(
           id, String(title).substring(0, 200), String(description).substring(0, 2000),
@@ -5493,7 +5511,7 @@ app.post('/api/internal/task-manager', express.json({ limit: '1mb' }), (req, res
           'todo', // status — immediately eligible for processQueue
           0,  // sort_order
           (chain_id ? callerTask?.session_id : null) || null, // session_id — only inherit for chain tasks
-          _mwt ? _mwt.workdir : workdir,
+          workdir,
           model || callerTask?.model || 'sonnet',
           mode || callerTask?.mode || 'auto',
           agent_mode || callerTask?.agent_mode || 'single',
@@ -5510,7 +5528,6 @@ app.post('/api/internal/task-manager', express.json({ limit: '1mb' }), (req, res
         ,
           botsLogic.inheritBotId(callerTask)  // bot_id: a bot's subtask stays that bot's
         );
-        if (_mwt) stmts.setTaskGit.run(_mwt.workdir, _mwt.git_root, _mwt.git_branch, id);
 
         // Set new columns that aren't in createTask prepared statement
         stmts.setTaskContext.run(contextJson, callerTaskId || null, id);
@@ -6838,7 +6855,11 @@ app.delete('/api/tasks/:id', (req, res) => {
   // user asked for by deleting the task — mirrors the session delete guard's
   // ?force bypass, not a silent skip of it.
   if (task?.git_root && task?.workdir) {
-    try { WM.removeWorktree({ projectDir: task.git_root, worktreeDir: task.workdir, branch: task.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on task delete', { tid, err: e.message }); }
+    if (_worktreeStillInUse(task.workdir, { exceptTask: tid })) {
+      log.info('worktree kept on task delete — still in use', { tid, workdir: task.workdir });
+    } else {
+      try { WM.removeWorktree({ projectDir: task.git_root, worktreeDir: task.workdir, branch: task.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on task delete', { tid, err: e.message }); }
+    }
   }
   res.json({ ok: true });
 });
@@ -7988,10 +8009,8 @@ app.delete('/api/sessions/:id', (req,res) => {
     // conversation in place) shares one worktree with the session it came from.
     // Removing it because ONE of them was deleted strands the other in a directory
     // that is gone — with `force: true` there is not even an error to notice.
-    let _sharers = 0;
-    try { _sharers = db.prepare(`SELECT COUNT(*) c FROM sessions WHERE workdir=? AND id<>?`).get(sessRow.workdir, sid).c; } catch {}
-    if (_sharers > 0) {
-      log.info('worktree kept — still in use by another session', { sid, workdir: sessRow.workdir, sharers: _sharers });
+    if (_worktreeStillInUse(sessRow.workdir, { exceptSession: sid })) {
+      log.info('worktree kept — still in use by another unit', { sid, workdir: sessRow.workdir });
     } else {
       try { WM.removeWorktree({ projectDir: sessRow.git_root, worktreeDir: sessRow.workdir, branch: sessRow.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on session delete', { sid, err: e.message }); }
     }
@@ -8044,7 +8063,13 @@ app.post('/api/sessions/bulk-delete', (req,res) => {
   // Never a bare rm -rf — always through git so .git/worktrees/<name> never goes stale.
   for (const s of sessRows) {
     if (s.git_root && s.workdir) {
-      try { WM.removeWorktree({ projectDir: s.git_root, worktreeDir: s.workdir, branch: s.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on bulk delete', { sid: s.id, err: e.message }); }
+      // Same rule as the single delete. Before compact inherited git_root a bulk
+      // delete could not reach a shared tree at all; now it can, so it needs the guard.
+      if (_worktreeStillInUse(s.workdir, { exceptSession: s.id })) {
+        log.info('worktree kept on bulk delete — still in use', { sid: s.id, workdir: s.workdir });
+      } else {
+        try { WM.removeWorktree({ projectDir: s.git_root, worktreeDir: s.workdir, branch: s.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on bulk delete', { sid: s.id, err: e.message }); }
+      }
     }
   }
   const del = db.transaction(() => {

--- a/server.js
+++ b/server.js
@@ -2175,6 +2175,14 @@ async function startTask(task) {
               // in place: removeWorktree also deletes the branch, which would strand
               // the unmerged commits with no ref pointing at them.
               if (task.git_root && task.workdir && task.git_branch) {
+                // The task's own session runs in THIS tree (startTask copies the task's
+                // workdir onto its sidecar), and a compact of that session shares it too.
+                // Merging is done, but the conversation is not: removing here left the
+                // next turn of a live chat in a cwd that no longer exists, silently,
+                // because force:true reports nothing.
+                if (_worktreeStillInUse(task.workdir, { exceptTask: task.id })) {
+                  log.info('worktree kept after auto-merge — a session still runs in it', { taskId: task.id, workdir: task.workdir });
+                } else
                 try { WM.removeWorktree({ projectDir: task.git_root, worktreeDir: task.workdir, branch: task.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed after task auto-merge', { taskId: task.id, err: e.message }); }
               }
             }
@@ -3499,7 +3507,30 @@ function _worktreeStillInUse(workdir, { exceptSession = null, exceptTask = null 
     const s = db.prepare(`SELECT COUNT(*) c FROM sessions WHERE workdir=? AND id<>COALESCE(?, '')`).get(workdir, exceptSession).c;
     const t = db.prepare(`SELECT COUNT(*) c FROM tasks    WHERE workdir=? AND id<>COALESCE(?, '')`).get(workdir, exceptTask).c;
     return (s + t) > 0;
-  } catch { return false; }
+  } catch (e) {
+    // Fail SAFE, not fail open. The caller's fallback is removeWorktree(force:true),
+    // which destroys a working tree and reports nothing — so a COUNT that failed must
+    // read as "in use". Leaving a stale worktree is recoverable; deleting a live one
+    // is not.
+    log.warn('worktree in-use check failed — keeping the tree', { workdir, err: e?.message });
+    return true;
+  }
+}
+
+/** Batch variant of _worktreeStillInUse: every id in `ids` is being deleted, so none
+ *  of them counts as a holder. Excluding only the current row lets two holders in one
+ *  batch keep each other's tree alive and then both vanish. */
+function _worktreeStillInUseExcluding(workdir, ids) {
+  if (!workdir) return false;
+  try {
+    const rows = db.prepare(`SELECT id FROM sessions WHERE workdir=?`).all(workdir).map(r => r.id);
+    if (rows.some(id => !ids.has(id))) return true;
+    const t = db.prepare(`SELECT COUNT(*) c FROM tasks WHERE workdir=?`).get(workdir).c;
+    return t > 0;
+  } catch (e) {
+    log.warn('worktree in-use check failed — keeping the tree', { workdir, err: e?.message });
+    return true;
+  }
 }
 
 /** Worktree isolation for units Telegram creates with direct SQL.
@@ -8003,21 +8034,20 @@ app.delete('/api/sessions/:id', (req,res) => {
   archiveSessionStats([sid]);
   // Best-effort: kill the interactive tmux session tied to this studio session
   try { killInteractiveTmux(sid); } catch {}
-  // Never a bare rm -rf — always through git so .git/worktrees/<name> never goes stale.
+  // Unlink recurring tasks from session (preserve the schedule), delete the rest
+  db.prepare(`UPDATE tasks SET session_id=NULL WHERE session_id=? AND recurrence IS NOT NULL`).run(sid);
+  stmts.deleteTasksBySession.run(sid);
+  // Worktree removal comes AFTER the cascade above, deliberately. Read before it, the
+  // count still saw the task rows this delete is about to remove, and answered "in use"
+  // for a tree nothing would own a line later — a leak instead of a stranding.
+  // Never a bare rm -rf: always through git, so .git/worktrees/<name> never goes stale.
   if (sessRow && sessRow.git_root && sessRow.workdir) {
-    // Refcount before removing: a compact (and anything else that continues a
-    // conversation in place) shares one worktree with the session it came from.
-    // Removing it because ONE of them was deleted strands the other in a directory
-    // that is gone — with `force: true` there is not even an error to notice.
     if (_worktreeStillInUse(sessRow.workdir, { exceptSession: sid })) {
       log.info('worktree kept — still in use by another unit', { sid, workdir: sessRow.workdir });
     } else {
       try { WM.removeWorktree({ projectDir: sessRow.git_root, worktreeDir: sessRow.workdir, branch: sessRow.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on session delete', { sid, err: e.message }); }
     }
   }
-  // Unlink recurring tasks from session (preserve the schedule), delete the rest
-  db.prepare(`UPDATE tasks SET session_id=NULL WHERE session_id=? AND recurrence IS NOT NULL`).run(sid);
-  stmts.deleteTasksBySession.run(sid);
   stmts.deleteSession.run(sid);
   // queued_messages has no FK to sessions, so the cascade never reaches it. Bulk delete
   // already does this; the single-session path did not, and boot-restore then resurrected
@@ -8061,13 +8091,21 @@ app.post('/api/sessions/bulk-delete', (req,res) => {
     try { fs.unlinkSync(path.join(os.tmpdir(), `ccsterm-sb-${id}.txt`)); } catch {}
   }
   // Never a bare rm -rf — always through git so .git/worktrees/<name> never goes stale.
+  //
+  // Excluding only the row being processed is wrong for a BATCH: delete an origin and
+  // its compact together and each one sees the other still present, both answer "in
+  // use", and the tree survives with nobody left to own it. The whole batch is excluded
+  // instead, and a tree is removed ONCE however many of its holders are in the batch.
+  const _bulkIds = new Set(sessRows.map(r => r.id));
+  const _bulkDone = new Set();
   for (const s of sessRows) {
     if (s.git_root && s.workdir) {
-      // Same rule as the single delete. Before compact inherited git_root a bulk
-      // delete could not reach a shared tree at all; now it can, so it needs the guard.
-      if (_worktreeStillInUse(s.workdir, { exceptSession: s.id })) {
+      if (_bulkDone.has(s.workdir)) {
+        // already handled for an earlier holder in this same batch
+      } else if (_worktreeStillInUseExcluding(s.workdir, _bulkIds)) {
         log.info('worktree kept on bulk delete — still in use', { sid: s.id, workdir: s.workdir });
       } else {
+        _bulkDone.add(s.workdir);
         try { WM.removeWorktree({ projectDir: s.git_root, worktreeDir: s.workdir, branch: s.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on bulk delete', { sid: s.id, err: e.message }); }
       }
     }

--- a/server.js
+++ b/server.js
@@ -1673,6 +1673,14 @@ async function startTask(task) {
       if (!sessionId) {
         sessionId = genId();
         stmts.createSession.run(sessionId, task.title.substring(0, 200), '[]', '[]', task.mode || 'auto', task.agent_mode || 'single', task.model || 'sonnet', task.workdir || null);
+        // This session is a SIDECAR of the task: it runs in the worktree the task was
+        // already given at creation time, so it inherits the metadata rather than
+        // minting a second tree. Copying `workdir` alone left git_root/git_branch NULL,
+        // which reads as "not isolated" to every consumer — the git chip, the
+        // status/commit/merge endpoints and the delete path all key off git_root.
+        if (task.git_root && task.workdir) {
+          try { stmts.setSessionGit.run(task.workdir, task.git_root, task.git_branch, sessionId); } catch {}
+        }
         stmts.setTaskSession.run(sessionId, task.id);
       }
       stmts.setTaskInProgress.run(task.id);
@@ -7743,7 +7751,13 @@ app.post('/api/sessions/import', (req, res) => {
       session.mode || 'auto',
       session.agent_mode || 'single',
       session.model || 'sonnet',
-      session.workdir || null
+      // git_root FIRST. An export taken from an isolated session carries the WORKTREE
+      // in `workdir` — a path that exists only on the machine it came from, and only
+      // until that worktree is removed. Importing it verbatim produced a session
+      // pointing at a directory that is not there, and that no project owns. The
+      // project root is the part that means something on the importing side; the
+      // import deliberately does NOT mint a worktree, because nothing has run in it yet.
+      session.git_root || session.workdir || null
     );
     const importMsg = db.prepare('INSERT INTO messages (session_id,role,type,content,tool_name,agent_id,reply_to_id,attachments,created_at) VALUES (?,?,?,?,?,?,?,?,COALESCE(?,CURRENT_TIMESTAMP))');
     const limit = Math.min(messages.length, 2000);
@@ -7889,6 +7903,14 @@ ${transcript}`;
     sess.model || 'sonnet',
     sess.workdir || null
   );
+  // A compact continues the SAME conversation in the SAME tree — it must not mint a
+  // second worktree, and it must not drop the metadata either. Copying `workdir`
+  // alone (which is what this did) left the new session pointing at a directory it
+  // did not know it shared: deleting the original ran removeWorktree and the compact
+  // was left with a workdir that no longer exists.
+  if (sess.git_root && sess.workdir) {
+    try { stmts.setSessionGit.run(sess.workdir, sess.git_root, sess.git_branch, newId); } catch {}
+  }
 
   // Insert the compact summary as the first user message so Claude gets context
   const contextMsg = `# 📋 Context from previous session\n\nThis is a continuation of a previous chat session. Here is the compact summary:\n\n${summaryText.trim()}`;
@@ -7928,7 +7950,17 @@ app.delete('/api/sessions/:id', (req,res) => {
   try { killInteractiveTmux(sid); } catch {}
   // Never a bare rm -rf — always through git so .git/worktrees/<name> never goes stale.
   if (sessRow && sessRow.git_root && sessRow.workdir) {
-    try { WM.removeWorktree({ projectDir: sessRow.git_root, worktreeDir: sessRow.workdir, branch: sessRow.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on session delete', { sid, err: e.message }); }
+    // Refcount before removing: a compact (and anything else that continues a
+    // conversation in place) shares one worktree with the session it came from.
+    // Removing it because ONE of them was deleted strands the other in a directory
+    // that is gone — with `force: true` there is not even an error to notice.
+    let _sharers = 0;
+    try { _sharers = db.prepare(`SELECT COUNT(*) c FROM sessions WHERE workdir=? AND id<>?`).get(sessRow.workdir, sid).c; } catch {}
+    if (_sharers > 0) {
+      log.info('worktree kept — still in use by another session', { sid, workdir: sessRow.workdir, sharers: _sharers });
+    } else {
+      try { WM.removeWorktree({ projectDir: sessRow.git_root, worktreeDir: sessRow.workdir, branch: sessRow.git_branch, force: true }); } catch (e) { log.warn('removeWorktree failed on session delete', { sid, err: e.message }); }
+    }
   }
   // Unlink recurring tasks from session (preserve the schedule), delete the rest
   db.prepare(`UPDATE tasks SET session_id=NULL WHERE session_id=? AND recurrence IS NOT NULL`).run(sid);

--- a/telegram-bot-forum.js
+++ b/telegram-bot-forum.js
@@ -783,6 +783,8 @@ class TelegramBotForum {
     const id = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
 
     this._api.stmts.insertSession.run(id, 'Telegram Session', workdir);
+    // Same write channel as a plain Telegram chat — see telegram-bot.js:_isolate.
+    this._api.isolate?.('session', id, workdir);
 
     ctx.sessionId = id;
     ctx.projectWorkdir = workdir;
@@ -1436,6 +1438,7 @@ class TelegramBotForum {
       const workdir = ctx.projectWorkdir || null;
 
       this._api.stmts.insertTask.run(id, title, workdir);
+      this._api.isolate?.('task', id, workdir);
 
       const workdirLine = workdir ? `\n📁 ${this._api.escHtml(workdir.split('/').filter(Boolean).pop())}` : '';
       const newTask = { id, title, status: 'backlog' };
@@ -1462,6 +1465,7 @@ class TelegramBotForum {
         const workdir = ctx.projectWorkdir || null;
 
         this._api.stmts.insertTask.run(id, title, workdir);
+        this._api.isolate?.('task', id, workdir);
 
         const workdirLine = workdir ? `\n📁 ${this._api.escHtml(workdir.split('/').filter(Boolean).pop())}` : '';
         const newTask = { id, title, status: 'backlog' };

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -173,6 +173,9 @@ class TelegramBot extends EventEmitter {
       chunkForTelegram: this._chunkForTelegram.bind(this),
       timeAgo: this._timeAgo.bind(this),
       stmts: this._stmts,
+      // Forum topics create sessions and tasks through the shared prepared statements
+      // above, so they bypass _isolate() entirely unless the hook travels with them.
+      isolate: this._isolate.bind(this),
       emit: this.emit.bind(this),
       getDirectContext: this._getContext.bind(this),
       saveDeviceContext: this._saveDeviceContext.bind(this),

--- a/telegram-bot.js
+++ b/telegram-bot.js
@@ -114,10 +114,26 @@ class TelegramBot extends EventEmitter {
    * @param {object} opts
    * @param {object} opts.log - Logger instance { info, warn, error, debug }
    */
+  /** Give a freshly-inserted Telegram unit its own worktree. Never throws: a bot
+   *  reply must not fail because git is unavailable on this host — the unit simply
+   *  stays in the project root, which is what it did before isolation existed. */
+  _isolate(kind, id, workdir) {
+    if (!this.isolateUnit || !workdir) return;
+    try { this.isolateUnit(kind, id, workdir); }
+    catch (e) { this.log.warn?.('telegram: worktree isolation skipped', { kind, id, err: e?.message }); }
+  }
+
   constructor(db, opts = {}) {
     super();
     this.db = db;
     this.log = opts.log || console;
+    // Injected by server.js, the way getRoster is. Telegram creates sessions and tasks
+    // by direct SQL, so worktree isolation cannot reach them from the HTTP layer — and
+    // without it a Telegram chat writes into the project root while a browser chat in
+    // the same project writes into its own worktree, and the browser's merge lands on
+    // top of Telegram's uncommitted work. Optional on purpose: with no injector the
+    // behaviour is exactly what it was before isolation existed.
+    this.isolateUnit = typeof opts.isolateUnit === 'function' ? opts.isolateUnit : null;
     this.token = null;
     this.running = false;
     this._pollTimer = null;
@@ -1544,6 +1560,7 @@ class TelegramBot extends EventEmitter {
       this.db.prepare(
         "INSERT INTO tasks (id, title, description, notes, status, sort_order, workdir) VALUES (?, ?, '', '', 'backlog', 0, ?)"
       ).run(id, title, workdir);
+      this._isolate('task', id, workdir);
 
       // Move to description input
       ctx.state = FSM_STATES.AWAITING_TASK_DESCRIPTION;
@@ -1605,6 +1622,7 @@ class TelegramBot extends EventEmitter {
         this.db.prepare(
           "INSERT INTO sessions (id, title, created_at, updated_at, workdir, model, engine) VALUES (?, ?, datetime('now'), datetime('now'), ?, 'sonnet', 'cli')"
         ).run(id, 'Telegram Session', workdir);
+        this._isolate('session', id, workdir);
         ctx.sessionId = id;
         this._saveDeviceContext(userId);
       }
@@ -1623,6 +1641,7 @@ class TelegramBot extends EventEmitter {
           this.db.prepare(
             "INSERT INTO sessions (id, title, created_at, updated_at, workdir, model, engine) VALUES (?, ?, datetime('now'), datetime('now'), ?, 'sonnet', 'cli')"
           ).run(id, 'Telegram Session', ctx.projectWorkdir);
+          this._isolate('session', id, ctx.projectWorkdir);
           ctx.sessionId = id;
         }
         this._saveDeviceContext(userId);
@@ -3121,6 +3140,7 @@ class TelegramBot extends EventEmitter {
           this.db.prepare(
             "INSERT INTO sessions (id, title, created_at, updated_at, workdir, model, engine) VALUES (?, ?, datetime('now'), datetime('now'), ?, 'sonnet', 'cli')"
           ).run(id, 'Telegram Session', workdir);
+          this._isolate('session', id, workdir);
           ctx.sessionId = id;
           this._saveDeviceContext(userId);
         }
@@ -3391,6 +3411,7 @@ class TelegramBot extends EventEmitter {
     this.db.prepare(
       "INSERT INTO sessions (id, title, created_at, updated_at, workdir, model, engine) VALUES (?, ?, datetime('now'), datetime('now'), ?, 'sonnet', 'cli')"
     ).run(id, 'Telegram Session', workdir);
+    this._isolate('session', id, workdir);
 
     ctx.sessionId = id;
     ctx.state = FSM_STATES.COMPOSING;
@@ -3477,6 +3498,7 @@ class TelegramBot extends EventEmitter {
     this.db.prepare(
       "INSERT INTO sessions (id, title, created_at, updated_at, workdir, model, engine) VALUES (?, ?, datetime('now'), datetime('now'), ?, 'sonnet', 'cli')"
     ).run(id, args || 'Telegram Session', workdir);
+    this._isolate('session', id, workdir);
 
     ctx.sessionId = id;
     ctx.state = FSM_STATES.COMPOSING;

--- a/test/worktree-manager.test.js
+++ b/test/worktree-manager.test.js
@@ -314,6 +314,52 @@ console.log('\nan existing identity is never overridden:');
   }
 }
 
+// ── Who inherits a worktree, and who must never remove one ─────────────────
+// Isolation is not "every creator gets a tree". Three sites CONTINUE work that
+// already has one, and each of them dropped the metadata that says so. Pinned as
+// source text (the technique test/render/script-scope.test.mjs uses) because the
+// property is which columns a call site carries, not what a pure function returns.
+console.log('\ncontinuation sites inherit instead of minting a second tree:');
+{
+  const fs2 = require('fs'), path2 = require('path');
+  const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
+  const near = (anchor, span = 900) => { const i = SRV.indexOf(anchor); return i === -1 ? null : SRV.slice(i, i + span); };
+
+  // A compact continues the same conversation in the same tree. Copying `workdir`
+  // alone left it sharing a directory it did not know it shared.
+  const cmp = near("const compactTitle =");
+  check('compact copies git_root/git_branch, not just workdir',
+    cmp !== null && /setSessionGit\.run\(sess\.workdir, sess\.git_root, sess\.git_branch, newId\)/.test(cmp), true);
+
+  // The task already has a worktree from POST /api/tasks; its session is a sidecar.
+  const st = near("stmts.setTaskSession.run(sessionId, task.id)", 1200);
+  const stBack = SRV.slice(Math.max(0, SRV.indexOf("stmts.setTaskSession.run(sessionId, task.id)") - 900), SRV.indexOf("stmts.setTaskSession.run(sessionId, task.id)"));
+  check('startTask copies the task git columns onto its sidecar session',
+    /setSessionGit\.run\(task\.workdir, task\.git_root, task\.git_branch, sessionId\)/.test(stBack), true);
+
+  // An export from an isolated session carries a worktree path that exists only on
+  // the machine it came from — and only until that worktree is removed.
+  const imp = near("String(session.title || 'Imported session')", 1200);
+  check('JSON import stores the PROJECT root, never the exported worktree',
+    imp !== null && /session\.git_root \|\| session\.workdir \|\| null/.test(imp), true);
+  check('and it does not mint a worktree for imported history',
+    imp !== null && !/setupUnitWorktree/.test(imp), true);
+}
+
+console.log('\na shared worktree is not removed while another session uses it:');
+{
+  const fs2 = require('fs'), path2 = require('path');
+  const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
+  const i = SRV.indexOf("removeWorktree failed on session delete");
+  const win = i === -1 ? '' : SRV.slice(Math.max(0, i - 1200), i);
+  // force:true means a removal that should not have happened reports no error at all,
+  // so the guard has to come BEFORE the call rather than being cleaned up after.
+  check('the delete path counts other sessions on the same workdir first',
+    /FROM sessions WHERE workdir=\? AND id<>\?/.test(win), true);
+  check('and the count is read before removeWorktree, not after',
+    win.indexOf('FROM sessions WHERE workdir=?') < win.indexOf('WM.removeWorktree'), true);
+}
+
 console.log(`\n${fail === 0 ? 'PASS' : 'FAIL'} — ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
 }

--- a/test/worktree-manager.test.js
+++ b/test/worktree-manager.test.js
@@ -354,10 +354,10 @@ console.log('\na shared worktree is not removed while another session uses it:')
   const win = i === -1 ? '' : SRV.slice(Math.max(0, i - 1200), i);
   // force:true means a removal that should not have happened reports no error at all,
   // so the guard has to come BEFORE the call rather than being cleaned up after.
-  check('the delete path counts other sessions on the same workdir first',
-    /FROM sessions WHERE workdir=\? AND id<>\?/.test(win), true);
-  check('and the count is read before removeWorktree, not after',
-    win.indexOf('FROM sessions WHERE workdir=?') < win.indexOf('WM.removeWorktree'), true);
+  check('the delete path asks whether the worktree is still in use',
+    /_worktreeStillInUse\(sessRow\.workdir/.test(win), true);
+  check('and asks before removeWorktree, not after',
+    win.indexOf('_worktreeStillInUse(') < win.indexOf('WM.removeWorktree'), true);
 }
 
 // ── Telegram is the third write channel, and it inserts its own SQL ─────────
@@ -373,8 +373,16 @@ console.log('\nTelegram creators are isolated through an injected policy:');
   const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
 
   // Six creators: five sessions and one task.
+  const FORUM = fs2.readFileSync(path2.join(__dirname, '..', 'telegram-bot-forum.js'), 'utf8');
   const calls = (TB.match(/this\._isolate\(/g) || []).length;
-  check('every Telegram creator calls the isolation hook', calls, 6);
+  check('every direct Telegram creator calls the isolation hook', calls, 6);
+  // Forum topics create through the SHARED prepared statements on the facade, so
+  // they bypass _isolate() entirely unless the hook travels with them. A count of
+  // six looked complete and hid three creators in the other file.
+  check('the facade carries the hook', /isolate: this\._isolate\.bind\(this\)/.test(TB), true);
+  check('every forum creator uses it', (FORUM.match(/_api\.isolate\?\./g) || []).length, 3);
+  check('and none of them is duplicated',
+    !/isolate\?\.\([^)]*\);\s*\n\s*this\._api\.isolate\?\./.test(FORUM), true);
   check('sessions and tasks are told apart',
     /_isolate\('session'/.test(TB) && /_isolate\('task'/.test(TB), true);
 
@@ -398,22 +406,39 @@ console.log('\nTelegram creators are isolated through an injected policy:');
   check('and for a session', /setSessionGit\.run/.test(injBody), true);
 }
 
-// MCP-created tasks are live writers, exactly like POST /api/tasks.
-console.log('\nan MCP-created task gets its own worktree:');
+// MCP create_task deliberately does NOT mint a worktree.
+// Review showed minting there ARMS the auto-merge in startTask (it keys on
+// git_root+git_branch, which were NULL for MCP children), walks past the chain
+// workdir lock, and breaks get_task_result/cancel_task, which still compare a raw
+// workdir where list_tasks already uses COALESCE. It belongs to the chain bundle.
+console.log('\nMCP create_task stays unisolated, on purpose:');
 {
   const fs2 = require('fs'), path2 = require('path');
   const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
-  const i2 = SRV.indexOf('let _mwt = null;');
-  // 1800, measured: setTaskGit lands 1377 chars in and the line itself is long.
-  // There is no second _mwt block in the file, so a wider window cannot catch a
-  // neighbouring one by accident.
+  const i2 = SRV.indexOf("const workdir = callerTask?.git_root || callerTask?.workdir || null;");
   const win = i2 === -1 ? '' : SRV.slice(i2, i2 + 1800);
-  check('it calls setupUnitWorktree', /setupUnitWorktree\('task', id, workdir\)/.test(win), true);
-  check('the row stores the worktree, not the project root', /_mwt \? _mwt\.workdir : workdir/.test(win), true);
-  check('and its git columns are recorded', /setTaskGit\.run\(_mwt\.workdir/.test(win), true);
-  // This is an MCP tool call: a bare throw answers the model with a stack trace.
-  check('GIT_UNAVAILABLE is reported as a result, not thrown',
-    /GIT_UNAVAILABLE.*\n.*res\.json\(\{ ok: false/.test(win) || /ok: false, error: e\.message/.test(win), true);
+  check('it inherits the caller PROJECT, never the caller worktree',
+    /callerTask\?\.git_root \|\| callerTask\?\.workdir/.test(win), true);
+  check('and does not mint a worktree', /setupUnitWorktree/.test(win), false);
+  check('the reason is recorded where the next person will look',
+    /chain bundle|auto-merge/.test(win), true);
+}
+
+// Every removal site refcounts, and counts BOTH tables.
+console.log('\nno worktree is removed while another unit lives in it:');
+{
+  const fs2 = require('fs'), path2 = require('path');
+  const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
+  check('the rule exists once', (SRV.match(/function _worktreeStillInUse/g) || []).length, 1);
+  const h = SRV.slice(SRV.indexOf('function _worktreeStillInUse'));
+  const hBody = h.slice(0, h.indexOf('\n}\n') + 3);
+  // Counting only sessions missed the case that destroys work: a RECURRING task
+  // survives its session's deletion and its auto-merge is skipped, so the worktree
+  // is its live cwd.
+  check('it counts sessions', /FROM sessions WHERE workdir=/.test(hBody), true);
+  check('and tasks', /FROM tasks\s+WHERE workdir=/.test(hBody), true);
+  // Three removal sites: session delete, task delete, bulk session delete.
+  check('every removal site is guarded', (SRV.match(/_worktreeStillInUse\(/g) || []).length, 4);
 }
 
 console.log(`\n${fail === 0 ? 'PASS' : 'FAIL'} — ${pass} passed, ${fail} failed`);

--- a/test/worktree-manager.test.js
+++ b/test/worktree-manager.test.js
@@ -360,6 +360,62 @@ console.log('\na shared worktree is not removed while another session uses it:')
     win.indexOf('FROM sessions WHERE workdir=?') < win.indexOf('WM.removeWorktree'), true);
 }
 
+// ── Telegram is the third write channel, and it inserts its own SQL ─────────
+// Without isolation a Telegram chat writes into the project root while a browser
+// chat in the same project writes into its own worktree — and the browser's merge
+// lands on top of Telegram's uncommitted work. telegram-bot.js does not require
+// server.js, so the policy is INJECTED; these pins are what keep the two halves
+// from drifting apart silently.
+console.log('\nTelegram creators are isolated through an injected policy:');
+{
+  const fs2 = require('fs'), path2 = require('path');
+  const TB = fs2.readFileSync(path2.join(__dirname, '..', 'telegram-bot.js'), 'utf8');
+  const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
+
+  // Six creators: five sessions and one task.
+  const calls = (TB.match(/this\._isolate\(/g) || []).length;
+  check('every Telegram creator calls the isolation hook', calls, 6);
+  check('sessions and tasks are told apart',
+    /_isolate\('session'/.test(TB) && /_isolate\('task'/.test(TB), true);
+
+  // A bot reply must not fail because git is missing on the host.
+  const h = TB.slice(TB.indexOf('  _isolate(kind, id, workdir) {'));
+  const hBody = h.slice(0, h.indexOf('\n  }') + 4);
+  check('the hook never throws out of a bot turn', /catch \(e\)/.test(hBody), true);
+  check('and is a no-op when no injector was provided',
+    /if \(!this\.isolateUnit/.test(hBody), true);
+
+  // Injected, not imported — and defined once, not copied per construction site.
+  check('server.js injects it at every TelegramBot construction',
+    (SRV.match(/isolateUnit: _isolateTelegramUnit/g) || []).length,
+    (SRV.match(/new TelegramBot\(db/g) || []).length);
+  check('the policy is defined once', (SRV.match(/function _isolateTelegramUnit/g) || []).length, 1);
+  // Writing the row's git columns is what makes the unit READ as isolated to the
+  // git chip, the status/commit/merge endpoints and the delete path.
+  const inj = SRV.slice(SRV.indexOf('function _isolateTelegramUnit'));
+  const injBody = inj.slice(0, inj.indexOf('\n}\n') + 3);
+  check('it records the git columns for a task', /setTaskGit\.run/.test(injBody), true);
+  check('and for a session', /setSessionGit\.run/.test(injBody), true);
+}
+
+// MCP-created tasks are live writers, exactly like POST /api/tasks.
+console.log('\nan MCP-created task gets its own worktree:');
+{
+  const fs2 = require('fs'), path2 = require('path');
+  const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
+  const i2 = SRV.indexOf('let _mwt = null;');
+  // 1800, measured: setTaskGit lands 1377 chars in and the line itself is long.
+  // There is no second _mwt block in the file, so a wider window cannot catch a
+  // neighbouring one by accident.
+  const win = i2 === -1 ? '' : SRV.slice(i2, i2 + 1800);
+  check('it calls setupUnitWorktree', /setupUnitWorktree\('task', id, workdir\)/.test(win), true);
+  check('the row stores the worktree, not the project root', /_mwt \? _mwt\.workdir : workdir/.test(win), true);
+  check('and its git columns are recorded', /setTaskGit\.run\(_mwt\.workdir/.test(win), true);
+  // This is an MCP tool call: a bare throw answers the model with a stack trace.
+  check('GIT_UNAVAILABLE is reported as a result, not thrown',
+    /GIT_UNAVAILABLE.*\n.*res\.json\(\{ ok: false/.test(win) || /ok: false, error: e\.message/.test(win), true);
+}
+
 console.log(`\n${fail === 0 ? 'PASS' : 'FAIL'} — ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);
 }

--- a/test/worktree-manager.test.js
+++ b/test/worktree-manager.test.js
@@ -457,6 +457,12 @@ console.log('\nno worktree is removed while another unit lives in it:');
   // Read before the cascade, the count still saw rows this delete is about to remove.
   check('session delete counts AFTER its cascade',
     SRV.indexOf('stmts.deleteTasksBySession.run(sid);') < SRV.indexOf('_worktreeStillInUse(sessRow.workdir'), true);
+  // The single delete was fixed first and the bulk one was left behind — this pin
+  // did not cover it, so the ordering bug looked closed while it was still live on
+  // the batch path. Both are pinned now.
+  check('bulk delete removes AFTER its cascade runs',
+    SRV.indexOf('del();') < SRV.indexOf('_worktreeStillInUseExcluding(s.workdir, _bulkIds)'), true);
+  check('and the cascade runs exactly once', (SRV.match(/^\s*del\(\);/gm) || []).length, 1);
 }
 
 console.log(`\n${fail === 0 ? 'PASS' : 'FAIL'} — ${pass} passed, ${fail} failed`);

--- a/test/worktree-manager.test.js
+++ b/test/worktree-manager.test.js
@@ -429,16 +429,34 @@ console.log('\nno worktree is removed while another unit lives in it:');
 {
   const fs2 = require('fs'), path2 = require('path');
   const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
-  check('the rule exists once', (SRV.match(/function _worktreeStillInUse/g) || []).length, 1);
-  const h = SRV.slice(SRV.indexOf('function _worktreeStillInUse'));
+  // Two variants, deliberately: the single-unit rule and a BATCH-aware one. Excluding
+  // only the current row lets an origin and its compact, deleted together, each see
+  // the other as a holder — both keep the tree, then both vanish.
+  check('the single-unit rule exists once', (SRV.match(/function _worktreeStillInUse\(/g) || []).length, 1);
+  check('and the batch rule exists once', (SRV.match(/function _worktreeStillInUseExcluding\(/g) || []).length, 1);
+  check('bulk delete uses the batch rule', /_worktreeStillInUseExcluding\(s\.workdir, _bulkIds\)/.test(SRV), true);
+  check('and removes a shared tree only once per batch', /_bulkDone\.has\(s\.workdir\)/.test(SRV), true);
+  const h = SRV.slice(SRV.indexOf('function _worktreeStillInUse('));
   const hBody = h.slice(0, h.indexOf('\n}\n') + 3);
   // Counting only sessions missed the case that destroys work: a RECURRING task
   // survives its session's deletion and its auto-merge is skipped, so the worktree
   // is its live cwd.
   check('it counts sessions', /FROM sessions WHERE workdir=/.test(hBody), true);
   check('and tasks', /FROM tasks\s+WHERE workdir=/.test(hBody), true);
-  // Three removal sites: session delete, task delete, bulk session delete.
-  check('every removal site is guarded', (SRV.match(/_worktreeStillInUse\(/g) || []).length, 4);
+  // FOUR removal sites, not three. The auto-merge in startTask was missed in the
+  // first pass and the count of 4 (1 def + 3 uses) made the gap look complete —
+  // the task's own sidecar session, and any compact of it, live in that same tree.
+  // 1 definition + 3 call sites (auto-merge, task delete, session delete). Bulk uses
+  // the batch variant, which is counted separately above.
+  check('the single-unit rule guards three sites', (SRV.match(/_worktreeStillInUse\(/g) || []).length, 4);
+  check('including the auto-merge removal', /_worktreeStillInUse\(task\.workdir, \{ exceptTask: task\.id \}\)/.test(SRV), true);
+  // A failed COUNT must not authorise removeWorktree(force:true): leaving a stale
+  // tree is recoverable, deleting a live one is not.
+  check('a failed check keeps the tree, never removes it',
+    /catch \(e\) \{[\s\S]*?return true;\s*\}/.test(hBody) && !/catch[\s\S]*?return false;/.test(hBody), true);
+  // Read before the cascade, the count still saw rows this delete is about to remove.
+  check('session delete counts AFTER its cascade',
+    SRV.indexOf('stmts.deleteTasksBySession.run(sid);') < SRV.indexOf('_worktreeStillInUse(sessRow.workdir'), true);
 }
 
 console.log(`\n${fail === 0 ? 'PASS' : 'FAIL'} — ${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Continues the isolation work from #73, guided by a consultation that **rejected my framing**. I had asked "3 of 19 creators are isolated, which of the other 16 should be?" — the answer was that several must deliberately NOT mint a worktree, and that the real defect was elsewhere: the sites which *continue* work in an existing tree were dropping the metadata that says so, and nothing stopped a tree being deleted out from under a live unit.

Three review rounds, every finding confirmed in code before acting.

## Inheritance — three sites that continue work in an existing worktree

- **compact** copied `workdir` but left `git_root`/`git_branch` NULL, so it read as *not isolated* to everything that matters (the git chip, the status/commit/merge endpoints, the delete path) while living inside an isolated tree. Deleting the original then removed the tree and left the compact pointing at nothing.
- **startTask()**'s session is a *sidecar* of a task that already has a worktree; it dropped the same two columns.
- **JSON import** stored the exported `workdir` — a worktree path that exists only on the machine it came from, and only until that worktree is removed. It now stores the project root and still mints nothing: no work has run in it yet.

## Coverage — the write channel that was invisible

**Telegram** creates sessions and tasks with direct SQL, so isolation could not reach it: a Telegram chat wrote into the project root while a browser chat in the same project wrote into its own worktree, and the browser's merge landed on top of Telegram's uncommitted work. Nine creators now isolate — six in `telegram-bot.js` and **three in `telegram-bot-forum.js`, which I missed entirely** in the first pass because they go through the shared prepared statements on the facade. My own test counted six and looked complete.

The policy is injected, not imported (`telegram-bot.js` takes its dependencies through the constructor, the way `getRoster` does), defined once, wired at every construction site, optional, and it never throws — a bot reply must not fail because git is missing on the host.

## Removal — a tree must never disappear under a live unit

Four call sites, all guarded now:

| site | what it stranded |
|---|---|
| auto-merge in `startTask` | **the task's own sidecar session**, and any compact of it — missed in the first pass |
| task delete | a sidecar chat left in a directory that is gone |
| session delete | the origin, when its compact was deleted |
| bulk delete | both, when origin and compact were in one batch |

Three subtler defects behind those:

- **The count failed OPEN.** `catch { return false }` meant an errored COUNT authorised `removeWorktree(force: true)` — an error became a deletion. It returns `true` now: a stale worktree is recoverable, a deleted live one is not.
- **The count ran BEFORE the cascade**, so it saw task rows the delete was about to remove and kept a tree nobody would own a line later. Fixed on the single path in round 2 — and the pin covered only that, so the same bug stayed live on the bulk path until round 3.
- **Bulk excluded only the current row.** Delete an origin and its compact together and each saw the other as a holder: both kept the tree, then both vanished.

Recurring tasks still count as holders, deliberately: the cascade unlinks rather than deletes them, their auto-merge is skipped, and that worktree is their live cwd.

## Deliberately NOT in this PR

**The chain bundle** — MCP `create_chain`, `POST /api/task-chains`, both dispatch doors, the auto-merge gating and `scheduleNextChainRun`. Isolating chain *sessions* without changing auto-merge would start the second task of every chain in a directory the first task's merge had already deleted: strictly worse than today. It moves as one piece.

**MCP `create_task` mint was tried and reverted.** Writing `git_root`/`git_branch` onto the row is what *arms* the auto-merge in `startTask` — it never ran for MCP children because those columns were NULL — and a unique worktree walks straight past the chain workdir lock. It also breaks `get_task_result`/`cancel_task`, which still compare a raw `workdir` where `list_tasks` already uses `COALESCE(git_root, workdir)`, so a parent would get 403 on the result of the task it just created. The reason is recorded at the call site.

## Verification

Full suite in a CI-equivalent container (Linux, Node 20, **no git identity**) — exit 0. `test/worktree-manager.test.js` is at 73 checks, including the counts and orderings that hid two of these bugs from an earlier version of itself. The local suite is flaky on my machine independently of this work: a clean `main` checkout fails the same way, so the container is the reference.