### PR TITLE
feat: choose model and reasoning effort when delegating (#76)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -271,23 +271,66 @@
     "qa-verification": {
       "label": "✅ QA Verification",
       "description": "Mandatory post-task verification loop — proves every requirement is met, fixes issues found",
-      "keywords": ["test", "verify", "qa", "check", "validation", "acceptance"],
+      "keywords": [
+        "test",
+        "verify",
+        "qa",
+        "check",
+        "validation",
+        "acceptance"
+      ],
       "file": "skills/qa-verification.md",
       "category": "quality"
     },
     "interview": {
       "label": "🎤 Interview First",
       "description": "Ask targeted questions before writing code — prevents wasted work on misunderstood requirements",
-      "keywords": ["requirements", "clarify", "questions", "scope", "ambiguous", "spec"],
+      "keywords": [
+        "requirements",
+        "clarify",
+        "questions",
+        "scope",
+        "ambiguous",
+        "spec"
+      ],
       "file": "skills/interview.md",
       "category": "workflow"
     },
     "plan-execute": {
       "label": "📐 Plan & Execute",
       "description": "Structure non-trivial tasks as plan → approve → step-by-step execution",
-      "keywords": ["plan", "steps", "refactor", "migration", "multi-file", "roadmap"],
+      "keywords": [
+        "plan",
+        "steps",
+        "refactor",
+        "migration",
+        "multi-file",
+        "roadmap"
+      ],
       "file": "skills/plan-execute.md",
       "category": "workflow"
+    }
+  },
+  "externalAgents": {
+    "claude": {
+      "label": "Claude Code",
+      "template": "claude --model {model} --effort {effort} {prompt}",
+      "interactive": "claude",
+      "resume": "claude --resume {sid}",
+      "resumeLast": "claude --continue",
+      "models": [
+        "haiku",
+        "sonnet",
+        "opus",
+        "fable"
+      ],
+      "efforts": [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max"
+      ]
     }
   }
 }

--- a/delegate-terminal.js
+++ b/delegate-terminal.js
@@ -92,7 +92,11 @@ function buildTerminalCommand(agentConfig, workdir, prompt, platform, opts = {})
     } else {
       // Drop the placeholder AND the flag in front of it: `--model {model}` with no
       // model must not become `--model` with the prompt as its argument.
-      cmd = cmd.replace(new RegExp(`\\s*(?:--?[\\w-]+[= ])?\\{${name}\\}`, 'g'), '');
+      // `[= ]` matched exactly ONE space, so `--model  {model}` (two spaces, easy to
+      // type) left the flag behind and it swallowed the prompt as its argument.
+      // Covers: `--model {m}`, `--model  {m}`, `--model={m}`, `-m {m}`, and a bare
+      // `{m}` with no flag at all.
+      cmd = cmd.replace(new RegExp(`\\s*(?:--?[\\w-]+(?:=|\\s+))?\\{${name}\\}`, 'g'), '');
     }
   }
   cmd = cmd.replace('{prompt}', shellEscape(prompt, platform));

--- a/delegate-terminal.js
+++ b/delegate-terminal.js
@@ -67,11 +67,35 @@ function shellEscape(s, platform) {
 
 /**
  * Build the shell command that cd's into the workdir and launches the agent CLI.
+ *
+ * `{model}` and `{effort}` are optional placeholders an agent template may use, e.g.
+ * `claude --model {model} {prompt}`. They are OMITTED, not blanked, when the caller
+ * chose nothing: a template that writes `--model {model}` would otherwise become
+ * `--model ` and the CLI would read the next token as the model name. The whole flag
+ * has to disappear with the value, so the substitution eats the surrounding run of
+ * spaces and leaves one.
+ *
+ * Every substituted value goes through shellEscape for the same reason `{prompt}`
+ * does: these come from an HTTP body, and a model name is a string like any other.
+ *
  * @param {{template?: string}} agentConfig
+ * @param {{model?: string, effort?: string}} [opts]
  */
-function buildTerminalCommand(agentConfig, workdir, prompt, platform) {
+function buildTerminalCommand(agentConfig, workdir, prompt, platform, opts = {}) {
   const template = agentConfig.template || '';
-  const cmd = template.replace('{prompt}', shellEscape(prompt, platform));
+  let cmd = template;
+  for (const [name, value] of [['model', opts.model], ['effort', opts.effort]]) {
+    const token = `{${name}}`;
+    if (!cmd.includes(token)) continue;
+    if (value) {
+      cmd = cmd.split(token).join(shellEscape(String(value), platform));
+    } else {
+      // Drop the placeholder AND the flag in front of it: `--model {model}` with no
+      // model must not become `--model` with the prompt as its argument.
+      cmd = cmd.replace(new RegExp(`\\s*(?:--?[\\w-]+[= ])?\\{${name}\\}`, 'g'), '');
+    }
+  }
+  cmd = cmd.replace('{prompt}', shellEscape(prompt, platform));
   // Not every agent CLI accepts a --cwd flag, so always cd into the workdir first
   return `cd ${shellEscape(workdir, platform)} && ${cmd}`;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -4257,6 +4257,22 @@ html[dir="rtl"] .notif-card.notif-progress  { border-right-color: #a78bfa; }
         <label data-i18n="dlg.agent">Agent</label>
         <div class="dlg-agent-cards" id="dlgAgentCards"></div>
       </div>
+      <!-- Shown only when the SELECTED agent declares a catalog. These are different
+           CLIs — "opus" means nothing to codex — so the options come from
+           config.externalAgents[<id>].models / .efforts, never from a list baked in
+           here that would go stale the moment a model is renamed. -->
+      <div class="form-row hidden" id="dlgTuningRow">
+        <div style="display:flex;gap:12px;flex-wrap:wrap">
+          <div class="hidden" id="dlgModelWrap" style="flex:1;min-width:150px">
+            <label data-i18n="dlg.model">Model</label>
+            <select id="dlgModel" class="inp"></select>
+          </div>
+          <div class="hidden" id="dlgEffortWrap" style="flex:1;min-width:150px">
+            <label data-i18n="dlg.effort">Reasoning effort</label>
+            <select id="dlgEffort" class="inp"></select>
+          </div>
+        </div>
+      </div>
       <div class="cmd-field">
         <label data-i18n="dlg.mode">Mode</label>
         <div class="dlg-mode-cards">
@@ -4664,6 +4680,7 @@ document.addEventListener('keydown', e => {
 // ─── i18n ─────────────────────────────────────────────────────────────────
 const TRANSLATIONS = {
   uk: {
+    'dlg.model':'Модель','dlg.effort':'Рівень міркування','dlg.tuning.default':'За замовчуванням',
     /* settings form (issue #40) */
     'cfg.tab.form':'⚙ Параметри',
     'cfg.search.ph':'Пошук параметра…',
@@ -5066,6 +5083,7 @@ const TRANSLATIONS = {
     'upd.available':'Доступне оновлення','upd.btn':'Оновити','upd.updating':'Оновлення… {time}','upd.copy_cmd':'Копіювати команду','upd.via_terminal':'Оновлення через термінал:','upd.copied':'Скопійовано ✓','upd.retry':'Повторити','upd.failed':'Оновлення не вдалося','upd.new_version':'Доступна нова версія {version}',
   },
   en: {
+    'dlg.model':'Model','dlg.effort':'Reasoning effort','dlg.tuning.default':'Default',
     /* settings form (issue #40) */
     'cfg.tab.form':'⚙ Settings',
     'cfg.search.ph':'Search settings…',
@@ -5468,6 +5486,7 @@ const TRANSLATIONS = {
     'upd.available':'Update available','upd.btn':'Update','upd.updating':'Updating… {time}','upd.copy_cmd':'Copy command','upd.via_terminal':'Update via Terminal:','upd.copied':'Copied ✓','upd.retry':'Retry','upd.failed':'Update failed','upd.new_version':'New version {version} available',
   },
   ru: {
+    'dlg.model':'Модель','dlg.effort':'Уровень рассуждений','dlg.tuning.default':'По умолчанию',
     /* settings form (issue #40) */
     'cfg.tab.form':'⚙ Параметры',
     'cfg.search.ph':'Поиск параметра…',
@@ -5870,6 +5889,7 @@ const TRANSLATIONS = {
     'upd.available':'Доступно обновление','upd.btn':'Обновить','upd.updating':'Обновление… {time}','upd.copy_cmd':'Копировать команду','upd.via_terminal':'Обновление через терминал:','upd.copied':'Скопировано ✓','upd.retry':'Повторить','upd.failed':'Обновление не удалось','upd.new_version':'Доступна новая версия {version}',
   },
   fr: {
+    'dlg.model':'Modèle','dlg.effort':'Niveau de raisonnement','dlg.tuning.default':'Par défaut',
     /* settings form (issue #40) */
     'cfg.tab.form':'⚙ Paramètres',
     'cfg.search.ph':'Rechercher un paramètre…',
@@ -6172,6 +6192,7 @@ const TRANSLATIONS = {
     "upd.available":"Mise à jour disponible","upd.btn":"Mettre à jour","upd.updating":"Mise à jour… {time}","upd.copy_cmd":"Copier la commande","upd.via_terminal":"Mise à jour via le terminal :","upd.copied":"Copié ✓","upd.retry":"Réessayer","upd.failed":"Échec de la mise à jour","upd.new_version":"Nouvelle version {version} disponible",
   },
   he: {
+    'dlg.model':'מודל','dlg.effort':'רמת חשיבה','dlg.tuning.default':'ברירת מחדל',
     /* settings form (issue #40) */
     'cfg.tab.form':'⚙ הגדרות',
     'cfg.search.ph':'חיפוש הגדרה…',
@@ -17114,6 +17135,7 @@ function openDelegateModal() {
         card.onclick = () => {
           container.querySelectorAll('.dlg-agent-card').forEach(c => c.classList.remove('selected'));
           card.classList.add('selected');
+          _dlgFillTuning(cfg);
         };
         const icon = document.createElement('span');
         icon.className = 'dlg-agent-icon';
@@ -17127,8 +17149,44 @@ function openDelegateModal() {
       }
     }
     $i('dlgTask').value = '';
+    _dlgFillTuning(null); // nothing picked yet — no catalog to show
     openModalOverlay('delegateModal', { onEscape: closeDelegateModal });
   });
+}
+
+/** Populate Model / Reasoning-effort for the agent just picked.
+ *
+ *  Options come from that agent's own config (`models`, `efforts`) — never a list
+ *  hardcoded here. These are different CLIs: "opus" means nothing to codex, and a
+ *  baked-in list goes stale the moment a model is renamed. An agent that declares
+ *  nothing shows no select, which is honest — the studio does not know what that CLI
+ *  accepts. The template decides too: without a `{model}` placeholder the value has
+ *  nowhere to go, so offering the choice would be a lie.
+ */
+function _dlgFillTuning(cfg) {
+  const tpl = String(cfg?.template || '');
+  const fill = (selId, wrapId, values, placeholder) => {
+    const sel = $i(selId), wrap = $i(wrapId);
+    if (!sel || !wrap) return false;
+    const list = Array.isArray(values) ? values.filter(v => typeof v === 'string' && v.trim()) : [];
+    const usable = list.length > 0 && tpl.includes('{' + placeholder + '}');
+    sel.textContent = '';
+    if (usable) {
+      const auto = document.createElement('option');
+      auto.value = ''; auto.textContent = t('dlg.tuning.default');
+      sel.appendChild(auto);
+      for (const v of list) {
+        const o = document.createElement('option');
+        o.value = v; o.textContent = v;
+        sel.appendChild(o);
+      }
+    }
+    wrap.classList.toggle('hidden', !usable);
+    return usable;
+  };
+  const m = fill('dlgModel', 'dlgModelWrap', cfg?.models, 'model');
+  const e = fill('dlgEffort', 'dlgEffortWrap', cfg?.efforts, 'effort');
+  $i('dlgTuningRow')?.classList.toggle('hidden', !(m || e));
 }
 
 function closeDelegateModal() {
@@ -17147,7 +17205,7 @@ async function submitDelegation() {
     const r = await fetch('/api/delegate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ agentId, mode, task, sessionId: currentSessionId }),
+      body: JSON.stringify({ agentId, mode, task, sessionId: currentSessionId, model: $i('dlgModel')?.value || undefined, effort: $i('dlgEffort')?.value || undefined }),
     });
     const d = await r.json();
     if (!r.ok) { toast(d.error || t('dlg.toast.fail').replace('{err}', ''), true); return; }

--- a/server.js
+++ b/server.js
@@ -10350,8 +10350,8 @@ function readDialog(delegationDir) {
   try { return fs.readFileSync(dialogPath, 'utf-8'); } catch { return ''; }
 }
 
-function buildTerminalCommand(agentConfig, workdir, prompt) {
-  return buildDelegateCommand(agentConfig, workdir, prompt, os.platform());
+function buildTerminalCommand(agentConfig, workdir, prompt, opts = {}) {
+  return buildDelegateCommand(agentConfig, workdir, prompt, os.platform(), opts);
 }
 
 function openTerminal(shellCommand) {
@@ -10729,9 +10729,18 @@ app.delete('/api/external-agents/:id', (req, res) => {
 // --- Delegation API ---
 
 app.post('/api/delegate', express.json(), (req, res) => {
-  const { agentId, mode, task, sessionId } = req.body;
+  const { agentId, mode, task, sessionId, model, effort } = req.body;
   if (!agentId || !task) return res.status(400).json({ error: 'agentId and task required' });
   if (!/^[a-zA-Z0-9_-]+$/.test(agentId)) return res.status(400).json({ error: 'Invalid agentId' });
+  // model/effort end up inside a shell command, so they are validated at the door
+  // rather than left to shellEscape alone — the same reason agentId is. The catalog
+  // is per-agent (config.externalAgents[id].models / .efforts): these are different
+  // CLIs, and what Claude calls "opus" means nothing to codex.
+  for (const [name, val] of [['model', model], ['effort', effort]]) {
+    if (val !== undefined && val !== null && val !== '' && !/^[a-zA-Z0-9._-]{1,40}$/.test(String(val))) {
+      return res.status(400).json({ error: `Invalid ${name}` });
+    }
+  }
 
   const config = loadConfig();
   const agentConfig = config.externalAgents[agentId];
@@ -10796,7 +10805,7 @@ app.post('/api/delegate', express.json(), (req, res) => {
   }
 
   // 5. Open terminal with the agent
-  const shellCommand = buildTerminalCommand(agentConfig, workdir, agentPrompt);
+  const shellCommand = buildTerminalCommand(agentConfig, workdir, agentPrompt, { model, effort });
   const termResult = openTerminal(shellCommand);
 
   if (!termResult.ok) {

--- a/server.js
+++ b/server.js
@@ -2937,7 +2937,13 @@ function buildSessionReplayContent(sessionId) {
 // has no --session-id / --resume: it uses the `codex resume <id>` subcommand). A
 // user whose CLI version differs edits these in the agent settings.
 const DEFAULT_EXTERNAL_AGENTS = {
-  claude:       { label: 'Claude Code',    interactive: 'claude',       newIdFlag: '--session-id {sid}', resume: 'claude --resume {sid}',       resumeLast: 'claude --continue' },
+  // `models` / `efforts` are the catalogs the delegate modal offers, and the ONLY
+  // values the endpoint will accept — the check is an allow-list, not a charset,
+  // because with a bare `{model}` in a template any well-formed string arrives as
+  // its own argv entry and could be a flag. A CLI with no catalog here simply
+  // offers no choice, which is honest: the studio does not know what it takes.
+  claude:       { label: 'Claude Code',    template: 'claude --model {model} --effort {effort} -p {prompt}', interactive: 'claude', newIdFlag: '--session-id {sid}', resume: 'claude --resume {sid}', resumeLast: 'claude --continue',
+                  models: ['haiku', 'sonnet', 'opus', 'fable'], efforts: ['low', 'medium', 'high', 'xhigh', 'max'] },
   codex:        { label: 'OpenAI Codex',   template: 'codex {prompt}',        interactive: 'codex',        resume: 'codex resume {sid}',        resumeLast: 'codex resume --last' },
   grok:         { label: 'Grok CLI',       interactive: 'grok',         newIdFlag: '-s {sid}',          resume: 'grok --resume {sid}',         resumeLast: 'grok --continue' },
   agy:          { label: 'Antigravity CLI', template: 'agy -i {prompt}',      interactive: 'agy',          resume: 'agy --conversation {sid}',  resumeLast: 'agy --continue' },
@@ -10678,6 +10684,8 @@ app.post('/api/external-agents', express.json(), (req, res) => {
   // never wipes the other half.
   const prev = config.externalAgents[id] || {};
   const next = { ...prev, label };
+  // Arrays are preserved by the `...prev` spread above; they have no form field yet,
+  // so editing an agent in the UI must not silently drop the catalogs it shipped with.
   for (const [k, v] of Object.entries({ template, interactive, newIdFlag, resume, resumeLast })) {
     if (v === undefined) continue;              // not submitted — keep whatever is stored
     const s = String(v).trim();
@@ -10732,19 +10740,27 @@ app.post('/api/delegate', express.json(), (req, res) => {
   const { agentId, mode, task, sessionId, model, effort } = req.body;
   if (!agentId || !task) return res.status(400).json({ error: 'agentId and task required' });
   if (!/^[a-zA-Z0-9_-]+$/.test(agentId)) return res.status(400).json({ error: 'Invalid agentId' });
-  // model/effort end up inside a shell command, so they are validated at the door
-  // rather than left to shellEscape alone — the same reason agentId is. The catalog
-  // is per-agent (config.externalAgents[id].models / .efforts): these are different
-  // CLIs, and what Claude calls "opus" means nothing to codex.
-  for (const [name, val] of [['model', model], ['effort', effort]]) {
-    if (val !== undefined && val !== null && val !== '' && !/^[a-zA-Z0-9._-]{1,40}$/.test(String(val))) {
-      return res.status(400).json({ error: `Invalid ${name}` });
-    }
-  }
+  // Deliberately an ALLOW-LIST against the agent's own catalog, not a charset.
+  //
+  // A charset check is not enough here and the reason is not shell quoting: with a
+  // bare `{model}` in the template the value becomes its own argv entry, so
+  // "--dangerously-skip-permissions" passes any sane character rule and arrives as a
+  // FLAG. shellEscape cannot help — the string is a perfectly valid single argument.
+  // Only "is this one of the values this agent declared" closes that.
+  //
+  // The catalog is per-agent because these are different CLIs: what Claude calls
+  // "opus" means nothing to codex.
 
   const config = loadConfig();
   const agentConfig = config.externalAgents[agentId];
   if (!agentConfig) return res.status(404).json({ error: `Agent "${agentId}" not configured` });
+  for (const [name, val, catalog] of [['model', model, agentConfig.models], ['effort', effort, agentConfig.efforts]]) {
+    if (val === undefined || val === null || val === '') continue;   // "" is "let the agent decide"
+    const allowed = Array.isArray(catalog) ? catalog.map(String) : [];
+    if (!allowed.includes(String(val))) {
+      return res.status(400).json({ error: `Unknown ${name} for agent "${agentId}"` });
+    }
+  }
   // Delegation needs a one-shot `template`. Terminal-only agents (interactive but
   // no template, e.g. the built-in `claude` entry) would otherwise sail through:
   // buildTerminalCommand yields a bare `cd <workdir> && `, a terminal window opens

--- a/test/delegate-terminal.test.js
+++ b/test/delegate-terminal.test.js
@@ -232,5 +232,20 @@ check('a hostile model name cannot break out of its quotes', () => {
   assert.ok(!/^[^']*; rm/.test(out), 'but never as an unquoted command');
 });
 
+// Every flag shape a real template uses. The first rule matched exactly ONE space,
+// so `--model  {model}` left the flag behind and it swallowed the prompt as its
+// argument — the failure this whole substitution exists to prevent.
+check('the flag is dropped for every shape, not just the canonical one', () => {
+  for (const tpl of ['claude --model {model} {prompt}',
+                     'claude --model  {model} {prompt}',
+                     'claude --model={model} {prompt}',
+                     'claude -m {model} {prompt}',
+                     'claude {model} {prompt}']) {
+    assert.strictEqual(
+      buildTerminalCommand({ template: tpl }, '/w', 'hi', 'linux', {}).split('&& ')[1],
+      "claude 'hi'", tpl);
+  }
+});
+
 if (failed) { console.log(`\n${failed} test(s) failed`); process.exit(1); }
 console.log('\nAll delegate-terminal tests passed');

--- a/test/delegate-terminal.test.js
+++ b/test/delegate-terminal.test.js
@@ -195,5 +195,42 @@ check('missing template degrades to a bare cd', () => {
   });
 }
 
+// ── {model} / {effort}: present when chosen, GONE when not (#76) ───────────
+// A template that writes `--model {model}` must not become `--model ` when the
+// user picked nothing — the CLI would read the next token (the prompt) as the
+// model name. The flag has to disappear together with the value.
+const TPL76 = { template: 'claude --model {model} --effort {effort} {prompt}' };
+const body76 = (c) => c.split('&& ')[1];
+
+check('{model}/{effort} are substituted and shell-escaped', () => {
+  assert.strictEqual(body76(buildTerminalCommand(TPL76, '/w', 'hi', 'linux', { model: 'opus', effort: 'high' })),
+    "claude --model 'opus' --effort 'high' 'hi'");
+});
+
+check('nothing chosen — the FLAGS disappear, not just the placeholders', () => {
+  assert.strictEqual(body76(buildTerminalCommand(TPL76, '/w', 'hi', 'linux', {})), "claude 'hi'");
+});
+
+check('one chosen — only the other flag disappears', () => {
+  assert.strictEqual(body76(buildTerminalCommand(TPL76, '/w', 'hi', 'linux', { model: 'opus' })), "claude --model 'opus' 'hi'");
+});
+
+check('a template without placeholders is untouched', () => {
+  assert.strictEqual(body76(buildTerminalCommand({ template: 'codex {prompt}' }, '/w', 'hi', 'linux', { model: 'opus' })), "codex 'hi'");
+});
+
+// Every caller written before #76 passes no opts at all.
+check('no opts behaves exactly like nothing chosen', () => {
+  assert.strictEqual(body76(buildTerminalCommand(TPL76, '/w', 'hi', 'linux')), "claude 'hi'");
+});
+
+// Same rule as {prompt}: these arrive in an HTTP body.
+check('a hostile model name cannot break out of its quotes', () => {
+  const q = String.fromCharCode(39);
+  const out = body76(buildTerminalCommand(TPL76, '/w', 'hi', 'linux', { model: q + '; rm -rf /; ' + q }));
+  assert.ok(out.includes('rm -rf'), 'the value survives');
+  assert.ok(!/^[^']*; rm/.test(out), 'but never as an unquoted command');
+});
+
 if (failed) { console.log(`\n${failed} test(s) failed`); process.exit(1); }
 console.log('\nAll delegate-terminal tests passed');


### PR DESCRIPTION
Closes #76.

## Design: placeholders, not a model list

`{model}` and `{effort}` join `{prompt}` in the agent's command template, and each agent declares its own catalogs:

```json
"claude": {
  "template": "claude --model {model} --effort {effort} -p {prompt}",
  "models":  ["haiku", "sonnet", "opus", "fable"],
  "efforts": ["low", "medium", "high", "xhigh", "max"]
}
```

The issue asks for the list to be **dynamic**, and this is what makes it so: these are different CLIs — codex, grok, opencode, claude — so a list baked into the studio would be wrong for most of them and stale for the rest. Renaming a model is a config edit, not a release.

A select appears only when the agent declares values **and** its template carries the matching placeholder. Offering a choice the command cannot carry would be a lie; an agent that declares nothing shows nothing, which is honest — the studio does not know what that CLI accepts.

## The security point, because I got it wrong first

My first cut validated against a charset and reasoned that `shellEscape` covered the rest. **It does not, and quoting was never the issue.** With a bare `{model}` in a template the value becomes its own argv entry, so `--dangerously-skip-permissions` passes any sane character rule and arrives as a *flag* — a perfectly valid single argument that no amount of escaping makes safe.

The endpoint now checks an **allow-list against that agent's own catalog**. Escaping is still applied on top, for the same reason `{prompt}` gets it.

## The flag disappears with the value

`--model {model}` with nothing chosen must not become `--model ` — the CLI would read the prompt as the model name. The substitution removes the placeholder together with the flag in front of it, in every shape a real template uses:

| template | nothing chosen |
|---|---|
| `--model {model}` | `claude 'hi'` |
| `--model  {model}` *(two spaces)* | `claude 'hi'` |
| `--model={model}` | `claude 'hi'` |
| `-m {model}` | `claude 'hi'` |
| `{model}` *(bare)* | `claude 'hi'` |

The first cut matched exactly one space, so the two-space form left the flag behind. All five are pinned, and the pin was verified to **fail** against the old rule.

## Reachability

The catalogs live in `DEFAULT_EXTERNAL_AGENTS`, not only in `config.example.json` — that file is seeded on *first* run, so an upgrade or a plain `node server.js` would have shown empty selects. Editing an agent in the UI preserves the arrays it shipped with.

Verified in a CI-equivalent container (Linux, Node 20): exit 0.