### PR TITLE
fix: a Kanban task's run settings stay editable after it has a session (#79)

### DIFF
--- a/public/kanban.html
+++ b/public/kanban.html
@@ -244,6 +244,7 @@ textarea.inp{ resize:vertical; min-height:80px; }
 .open-link:hover{ background:var(--abg); }
 
 /* ─── New session config (in Add modal) ─── */
+.sc-note{ font-size:11px; color:var(--muted); line-height:1.45; margin:2px 0 8px; }
 .new-sess-hdr{ font-size:11px; color:var(--muted); font-weight:700; text-transform:uppercase; letter-spacing:.5px; margin-bottom:8px; }
 .sess-cfg{ border:1px solid var(--border); border-radius:var(--r-md); padding:12px 14px; background:var(--s2); }
 .sc-row{ display:flex; align-items:center; gap:7px; flex-wrap:wrap; }
@@ -456,6 +457,7 @@ textarea.inp{ resize:vertical; min-height:80px; }
 // ─── i18n ─────────────────────────────────────────────────────────────────
 const TR = {
   uk: {
+    'modal.task_cfg':'Параметри запуску','modal.task_cfg_note':'Діють на наступний запуск. Модель уже створеної сесії не змінюється — нова модель застосується до наступної сесії цієї задачі.',
     'tb.bot':'Бот','tb.bot.none':'без бота','tb.bot.tip':'Задача виконається промптом і моделлю цього бота',
     'hdr.title':'Kanban','hdr.add':'Завдання',
     'proj.label':'Проект:','proj.all':'— Всі проекти —','proj.recent':'Нещодавні','proj.search':'Пошук проекту...','search.empty':'Не знайдено',
@@ -503,6 +505,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Підписка','tmux.required':'Потрібен tmux на сервері',
   },
   en: {
+    'modal.task_cfg':'Run settings','modal.task_cfg_note':'Applied on the next run. An existing session keeps its own model — a new model applies to the next session this task creates.',
     'tb.bot':'Bot','tb.bot.none':'no bot','tb.bot.tip':'The task runs with this bot\'s prompt and model',
     'hdr.title':'Kanban','hdr.add':'Task',
     'proj.label':'Project:','proj.all':'— All projects —','proj.recent':'Recent','proj.search':'Search project...','search.empty':'Not found',
@@ -550,6 +553,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Subscription','tmux.required':'tmux is required on the server',
   },
   ru: {
+    'modal.task_cfg':'Параметры запуска','modal.task_cfg_note':'Применяются к следующему запуску. Модель уже созданной сессии не меняется — новая модель применится к следующей сессии этой задачи.',
     'tb.bot':'Бот','tb.bot.none':'без бота','tb.bot.tip':'Задача выполнится промптом и моделью этого бота',
     'hdr.title':'Kanban','hdr.add':'Задача',
     'proj.label':'Проект:','proj.all':'— Все проекты —','proj.recent':'Недавние','proj.search':'Поиск проекта...','search.empty':'Не найдено',
@@ -597,6 +601,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Подписка','tmux.required':'Нужен tmux на сервере',
   },
   fr: {
+    'modal.task_cfg':'Paramètres d exécution','modal.task_cfg_note':'Appliqués au prochain lancement. Une session existante conserve son modèle — le nouveau modèle s appliquera à la prochaine session de cette tâche.',
     'tb.bot':'Bot','tb.bot.none':'sans bot','tb.bot.tip':"La tâche s'exécute avec le prompt et le modèle de ce bot",
     'hdr.title':'Kanban','hdr.add':'Tâche',
     'proj.label':'Projet :','proj.all':'— Tous les projets —','proj.recent':'Récents','proj.search':'Rechercher un projet…','search.empty':'Aucun résultat',
@@ -644,6 +649,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Abonnement','tmux.required':'tmux est requis sur le serveur',
   },
   he: {
+    'modal.task_cfg':'הגדרות הרצה','modal.task_cfg_note':'חלות על ההרצה הבאה. סשן קיים שומר על המודל שלו — מודל חדש יחול על הסשן הבא של משימה זו.',
     'tb.bot':'בוט','tb.bot.none':'ללא בוט','tb.bot.tip':'המשימה תרוץ עם הפרומפט והמודל של הבוט הזה',
     'hdr.title':'קנבן','hdr.add':'משימה',
     'proj.label':'פרויקט:','proj.all':'— כל הפרויקטים —','proj.recent':'אחרונים','proj.search':'חיפוש פרויקט...','search.empty':'לא נמצא',
@@ -1872,7 +1878,18 @@ function buildForm(tk={}){
   const statusOpts=COLS.map(c=>`<option value="${c.id}"${tk.status===c.id?' selected':''}>${escH(t('col.'+c.id))}</option>`).join('');
   const sessOpts=`<option value="">${escH(isNew?t('modal.new_session'):t('modal.no_session'))}</option>`+
     sessions.map(s=>`<option value="${s.id}"${tk.session_id===s.id?' selected':''}>${escH((s.title||s.id).substring(0,60))}</option>`).join('');
-  const visClass=!tk.session_id?' visible':'';
+  // Shown whenever we are EDITING, not only while a session is being created.
+  //
+  // These dials are read from the TASK row on every run, not from the session:
+  // `effectiveTaskMaxTurns = task.max_turns`, `mode: task.mode`, `task.effort`,
+  // `task.run_engine` (server.js, startTask). Hiding them once a session existed
+  // meant the settings that actually drive each run became uneditable the moment
+  // the task first ran — issue #79.
+  //
+  // `model` is the one exception and the header says so: the runner resolves
+  // `session?.model || task.model`, so an existing session keeps its own model and
+  // a change here applies to the next session this task creates.
+  const visClass=(!tk.session_id||!isNew)?' visible':'';
   const schedInfoHtml=(tk.scheduled_at&&(tk.status==='todo'||tk.status==='backlog'))?`
     <div class="sched-info">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 12"/></svg>
@@ -1928,7 +1945,8 @@ function buildForm(tk={}){
       <div><label class="lbl">${t('modal.session')}</label><select id="fSession" class="sel" onchange="onFSessionChange()">${sessOpts}</select></div>
     </div>
     <div id="newSessCfg" class="new-sess-cfg${visClass}">
-      <div class="new-sess-hdr">${t('modal.new_sess_cfg')}</div>
+      <div class="new-sess-hdr">${isNew?t('modal.new_sess_cfg'):t('modal.task_cfg')}</div>
+      ${(isNew||!tk.session_id)?'':`<div class="sc-note">${escH(t('modal.task_cfg_note'))}</div>`}
       <div class="sc-row">
         <div class="sc-seg" data-group="mode">
           <span class="sc-lbl">${t('tb.mode')}</span>
@@ -2062,7 +2080,10 @@ function scOpt(btn){
 function onFSessionChange(){
   const hasSess=!!$i('fSession')?.value;
   const cfg=$i('newSessCfg');
-  if(cfg)cfg.classList.toggle('visible',!hasSess);
+  // While CREATING, the block is about the session that is about to be made, so it
+  // follows the session picker. While EDITING it stays: mode, turns, effort and
+  // engine are read off the task on every run regardless of which session it uses.
+  if(cfg&&modalMode!=='edit')cfg.classList.toggle('visible',!hasSess);
 }
 function getSessCfg(){
   const defaults={model:'sonnet',mode:'auto',agent:'single',engine:'cli',run_engine:kbSettings.run_engine||'api',maxTurns:30,effort:'',bot_id:null};

--- a/test/kanban-schedule.test.js
+++ b/test/kanban-schedule.test.js
@@ -94,5 +94,34 @@ console.log('combined save path:');
   check("clearing the date on a 'daily' task clears the repeat", kbEffectiveRecurrence(buildRecurToken(), null), null);
 }
 
+// ── Run settings stay editable after the task has a session (#79) ──────────
+// These dials are read off the TASK row on every run — `effectiveTaskMaxTurns =
+// task.max_turns`, `mode: task.mode`, `task.effort`, `task.run_engine` in
+// startTask — but the block holding them was shown only while a session was being
+// created. The moment a task first ran, the settings that actually drive each run
+// became uneditable.
+console.log('\nKanban task run settings remain editable:');
+{
+  const fs2 = require('fs'), path2 = require('path');
+  const KB = fs2.readFileSync(path2.join(__dirname, '..', 'public', 'kanban.html'), 'utf8');
+  const i2 = KB.indexOf('function buildForm(tk={}){');
+  const form = KB.slice(i2, KB.indexOf('\nfunction ', i2 + 10));
+
+  check('the settings block is visible when editing, not only for a new session',
+    /const visClass=\(!tk\.session_id\|\|!isNew\)\?' visible':''/.test(form), true);
+
+  // The session picker must stop hiding it while editing, or the toggle undoes
+  // the line above the moment the user touches the dropdown.
+  const oc = KB.slice(KB.indexOf('function onFSessionChange()'));
+  const ocBody = oc.slice(0, oc.indexOf('\n}') + 2);
+  check('the session picker does not hide it while editing',
+    /modalMode!=='edit'/.test(ocBody), true);
+
+  // model is the one dial the session wins on (`session?.model || task.model`),
+  // so the form has to say that rather than imply the change takes effect now.
+  check('the note explains what model does on an existing session',
+    /modal\.task_cfg_note/.test(form), true);
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Closes #79.

## The dials were there — the block was gated

Mode, agent, model, turns and effort are all in the task form already, and `saveTask()` plus `updateTask` carry all five. Nothing server-side was missing.

The block holding them was gated on `!tk.session_id` — shown only while a **new session** was being configured. The moment a task first ran and got a session, the settings disappeared.

## Why that gate is wrong for a task

These are read off the **task row on every run**, not off the session:

```js
const effectiveTaskMaxTurns = task.max_turns || UNATTENDED_MAX_TURNS;
mode:  task.mode || ...
task.effort, task.run_engine
```

So the settings that actually drive each run became uneditable exactly when the user had run the task once and learned enough to want to change them. That is the workflow in the report: recreate the task to change how it runs.

## `model` is the one exception, and the form now says so

The runner resolves `session?.model || task.model` — an existing session keeps its own model. Rather than let the UI imply the change takes effect immediately, the form shows a note, and only for a task that already has a session, where the caveat is real:

> Applied on the next run. An existing session keeps its own model — a new model applies to the next session this task creates.

The header switches from "New session config" to "Run settings" when editing, because that is what it is at that point.

`onFSessionChange()` no longer hides the block while editing — otherwise touching the session dropdown undid the fix a second later.

## Verification

`test/kanban-schedule.test.js` pins all three: the visibility rule, that the session picker no longer hides it while editing, and that the note is present. Full suite in a CI-equivalent container (Linux, Node 20): exit 0.