### PR TITLE
fix: five post-release review findings on v7.13.0

### DIFF
--- a/delegate-terminal.js
+++ b/delegate-terminal.js
@@ -124,7 +124,10 @@ function buildTerminalCommand(agentConfig, workdir, prompt, platform, opts = {})
         if (out.length) out.push(' ');
       }
     }
-    cmd = out.join('').replace(/\s+/g, ' ').trim();
+    // No global whitespace squeeze: the drop path already inserts exactly one space
+    // where a token was removed, and collapsing the WHOLE command would rewrite
+    // spacing the template author meant to keep — `--system "a  b"` is a real thing.
+    cmd = out.join('').trim();
   }
   cmd = cmd.replace('{prompt}', shellEscape(prompt, platform));
   // Not every agent CLI accepts a --cwd flag, so always cd into the workdir first

--- a/delegate-terminal.js
+++ b/delegate-terminal.js
@@ -83,21 +83,48 @@ function shellEscape(s, platform) {
  */
 function buildTerminalCommand(agentConfig, workdir, prompt, platform, opts = {}) {
   const template = agentConfig.template || '';
+  // Token-wise, not regex-wise. A regex over the whole template got three shapes
+  // wrong at once, and the third was silent corruption rather than a visible break:
+  //
+  //   --model "{model}"        with a value -> --model "'opus'"   (double-quoted,
+  //                                            so the CLI receives 'opus' WITH quotes)
+  //   --model "{model}"        with none    -> --model ""         (empty flag)
+  //   --model={model},{model}  with none    -> claude,            (command destroyed)
+  //
+  // Splitting on whitespace makes each of those a local decision: a token either
+  // contains the placeholder or it does not.
   let cmd = template;
   for (const [name, value] of [['model', opts.model], ['effort', opts.effort]]) {
     const token = `{${name}}`;
     if (!cmd.includes(token)) continue;
-    if (value) {
-      cmd = cmd.split(token).join(shellEscape(String(value), platform));
-    } else {
-      // Drop the placeholder AND the flag in front of it: `--model {model}` with no
-      // model must not become `--model` with the prompt as its argument.
-      // `[= ]` matched exactly ONE space, so `--model  {model}` (two spaces, easy to
-      // type) left the flag behind and it swallowed the prompt as its argument.
-      // Covers: `--model {m}`, `--model  {m}`, `--model={m}`, `-m {m}`, and a bare
-      // `{m}` with no flag at all.
-      cmd = cmd.replace(new RegExp(`\\s*(?:--?[\\w-]+(?:=|\\s+))?\\{${name}\\}`, 'g'), '');
+    const parts = cmd.split(/(\s+)/);            // keep the separators, so spacing survives
+    const out = [];
+    for (let k = 0; k < parts.length; k++) {
+      const part = parts[k];
+      if (!part.includes(token)) { out.push(part); continue; }
+      if (value) {
+        // Strip quotes the template author wrapped around the placeholder: the value
+        // is shell-escaped here, and escaping inside quotes nests them.
+        // Unwrap quotes the template author put AROUND the placeholder before
+        // substituting: the value is shell-escaped here, so quoting it again nests
+        // the quotes and the CLI receives them as part of the value.
+        const bare = part.split(`"${token}"`).join(token).split(`'${token}'`).join(token);
+        out.push(bare.split(token).join(shellEscape(String(value), platform)));
+      } else {
+        // Drop this token, and the flag before it when that flag exists only to
+        // carry it — `--model {model}` must not leave `--model` to eat the prompt.
+        while (out.length && /^\s+$/.test(out[out.length - 1])) out.pop();
+        const prev = out[out.length - 1];
+        if (prev && /^--?[\w-]+$/.test(prev)) {
+          out.pop();
+          while (out.length && /^\s+$/.test(out[out.length - 1])) out.pop();
+        }
+        // Skip the separator that followed the dropped token.
+        if (/^\s+$/.test(parts[k + 1] || '')) k++;
+        if (out.length) out.push(' ');
+      }
     }
+    cmd = out.join('').replace(/\s+/g, ' ').trim();
   }
   cmd = cmd.replace('{prompt}', shellEscape(prompt, platform));
   // Not every agent CLI accepts a --cwd flag, so always cd into the workdir first

--- a/public/kanban.html
+++ b/public/kanban.html
@@ -457,7 +457,7 @@ textarea.inp{ resize:vertical; min-height:80px; }
 // ─── i18n ─────────────────────────────────────────────────────────────────
 const TR = {
   uk: {
-    'modal.task_cfg':'Параметри запуску','modal.task_cfg_note':'Діють на наступний запуск: ліміт кроків, зусилля, двигун. Модель і тип агента можуть не застосуватися до вже створеної сесії — вони діють, коли задача створює нову. Режим залежить від двигуна.',
+    'modal.task_cfg':'Параметри запуску','modal.task_cfg_note':'Зміни зберігаються і впливають на наступний запуск, а не на поточний. Які саме дилки подіють, залежить від двигуна задачі й від того, чи вона вже має сесію.',
     'tb.bot':'Бот','tb.bot.none':'без бота','tb.bot.tip':'Задача виконається промптом і моделлю цього бота',
     'hdr.title':'Kanban','hdr.add':'Завдання',
     'proj.label':'Проект:','proj.all':'— Всі проекти —','proj.recent':'Нещодавні','proj.search':'Пошук проекту...','search.empty':'Не знайдено',
@@ -505,7 +505,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Підписка','tmux.required':'Потрібен tmux на сервері',
   },
   en: {
-    'modal.task_cfg':'Run settings','modal.task_cfg_note':'Applied on the next run: turns, effort, engine. Model and agent may not apply to a session that already exists — they take effect when the task creates a new one. Mode depends on the engine.',
+    'modal.task_cfg':'Run settings','modal.task_cfg_note':'Changes are saved and affect the next run, not the one in progress. Which dials take effect depends on the task engine and on whether it already has a session.',
     'tb.bot':'Bot','tb.bot.none':'no bot','tb.bot.tip':'The task runs with this bot\'s prompt and model',
     'hdr.title':'Kanban','hdr.add':'Task',
     'proj.label':'Project:','proj.all':'— All projects —','proj.recent':'Recent','proj.search':'Search project...','search.empty':'Not found',
@@ -553,7 +553,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Subscription','tmux.required':'tmux is required on the server',
   },
   ru: {
-    'modal.task_cfg':'Параметры запуска','modal.task_cfg_note':'Применяются к следующему запуску: лимит шагов, усилие, движок. Модель и тип агента могут не примениться к уже созданной сессии — они действуют, когда задача создаёт новую. Режим зависит от движка.',
+    'modal.task_cfg':'Параметры запуска','modal.task_cfg_note':'Изменения сохраняются и влияют на следующий запуск, а не на текущий. Какие именно настройки подействуют, зависит от движка задачи и от того, есть ли у неё уже сессия.',
     'tb.bot':'Бот','tb.bot.none':'без бота','tb.bot.tip':'Задача выполнится промптом и моделью этого бота',
     'hdr.title':'Kanban','hdr.add':'Задача',
     'proj.label':'Проект:','proj.all':'— Все проекты —','proj.recent':'Недавние','proj.search':'Поиск проекта...','search.empty':'Не найдено',
@@ -601,7 +601,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Подписка','tmux.required':'Нужен tmux на сервере',
   },
   fr: {
-    'modal.task_cfg':'Paramètres d exécution','modal.task_cfg_note':'Appliqués au prochain lancement : tours, effort, moteur. Le modèle et l agent peuvent ne pas s appliquer à une session existante — ils prennent effet quand la tâche en crée une nouvelle. Le mode dépend du moteur.',
+    'modal.task_cfg':'Paramètres d exécution','modal.task_cfg_note':'Les modifications sont enregistrées et affectent le prochain lancement, pas celui en cours. Les réglages qui prennent effet dépendent du moteur de la tâche et du fait qu elle ait déjà une session.',
     'tb.bot':'Bot','tb.bot.none':'sans bot','tb.bot.tip':"La tâche s'exécute avec le prompt et le modèle de ce bot",
     'hdr.title':'Kanban','hdr.add':'Tâche',
     'proj.label':'Projet :','proj.all':'— Tous les projets —','proj.recent':'Récents','proj.search':'Rechercher un projet…','search.empty':'Aucun résultat',
@@ -649,7 +649,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Abonnement','tmux.required':'tmux est requis sur le serveur',
   },
   he: {
-    'modal.task_cfg':'הגדרות הרצה','modal.task_cfg_note':'חלים על ההרצה הבאה: תורות, מאמץ, מנוע. מודל וסוג הסוכן עשויים שלא לחול על סשן קיים — הם נכנסים לתוקף כשהמשימה יוצרת סשן חדש. המצב תלוי במנוע.',
+    'modal.task_cfg':'הגדרות הרצה','modal.task_cfg_note':'השינויים נשמרים ומשפיעים על ההרצה הבאה, לא על זו שרצה כעת. אילו הגדרות ייכנסו לתוקף תלוי במנוע המשימה ובשאלה אם כבר יש לה סשן.',
     'tb.bot':'בוט','tb.bot.none':'ללא בוט','tb.bot.tip':'המשימה תרוץ עם הפרומפט והמודל של הבוט הזה',
     'hdr.title':'קנבן','hdr.add':'משימה',
     'proj.label':'פרויקט:','proj.all':'— כל הפרויקטים —','proj.recent':'אחרונים','proj.search':'חיפוש פרויקט...','search.empty':'לא נמצא',

--- a/public/kanban.html
+++ b/public/kanban.html
@@ -457,7 +457,7 @@ textarea.inp{ resize:vertical; min-height:80px; }
 // ─── i18n ─────────────────────────────────────────────────────────────────
 const TR = {
   uk: {
-    'modal.task_cfg':'Параметри запуску','modal.task_cfg_note':'Діють на наступний запуск: ліміт кроків, зусилля, двигун. Модель, режим і тип агента застосовуються лише коли задача створює НОВУ сесію — наявна сесія лишає свої.',
+    'modal.task_cfg':'Параметри запуску','modal.task_cfg_note':'Діють на наступний запуск: ліміт кроків, зусилля, двигун. Модель і тип агента можуть не застосуватися до вже створеної сесії — вони діють, коли задача створює нову. Режим залежить від двигуна.',
     'tb.bot':'Бот','tb.bot.none':'без бота','tb.bot.tip':'Задача виконається промптом і моделлю цього бота',
     'hdr.title':'Kanban','hdr.add':'Завдання',
     'proj.label':'Проект:','proj.all':'— Всі проекти —','proj.recent':'Нещодавні','proj.search':'Пошук проекту...','search.empty':'Не знайдено',
@@ -505,7 +505,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Підписка','tmux.required':'Потрібен tmux на сервері',
   },
   en: {
-    'modal.task_cfg':'Run settings','modal.task_cfg_note':'Applied on the next run: turns, effort, engine. Model, mode and agent apply only when the task creates a NEW session — an existing session keeps its own.',
+    'modal.task_cfg':'Run settings','modal.task_cfg_note':'Applied on the next run: turns, effort, engine. Model and agent may not apply to a session that already exists — they take effect when the task creates a new one. Mode depends on the engine.',
     'tb.bot':'Bot','tb.bot.none':'no bot','tb.bot.tip':'The task runs with this bot\'s prompt and model',
     'hdr.title':'Kanban','hdr.add':'Task',
     'proj.label':'Project:','proj.all':'— All projects —','proj.recent':'Recent','proj.search':'Search project...','search.empty':'Not found',
@@ -553,7 +553,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Subscription','tmux.required':'tmux is required on the server',
   },
   ru: {
-    'modal.task_cfg':'Параметры запуска','modal.task_cfg_note':'Применяются к следующему запуску: лимит шагов, усилие, движок. Модель, режим и тип агента применяются только когда задача создаёт НОВУЮ сессию — существующая сохраняет свои.',
+    'modal.task_cfg':'Параметры запуска','modal.task_cfg_note':'Применяются к следующему запуску: лимит шагов, усилие, движок. Модель и тип агента могут не примениться к уже созданной сессии — они действуют, когда задача создаёт новую. Режим зависит от движка.',
     'tb.bot':'Бот','tb.bot.none':'без бота','tb.bot.tip':'Задача выполнится промптом и моделью этого бота',
     'hdr.title':'Kanban','hdr.add':'Задача',
     'proj.label':'Проект:','proj.all':'— Все проекты —','proj.recent':'Недавние','proj.search':'Поиск проекта...','search.empty':'Не найдено',
@@ -601,7 +601,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Подписка','tmux.required':'Нужен tmux на сервере',
   },
   fr: {
-    'modal.task_cfg':'Paramètres d exécution','modal.task_cfg_note':'Appliqués au prochain lancement : tours, effort, moteur. Le modèle, le mode et l agent ne s appliquent que lorsque la tâche crée une NOUVELLE session — une session existante conserve les siens.',
+    'modal.task_cfg':'Paramètres d exécution','modal.task_cfg_note':'Appliqués au prochain lancement : tours, effort, moteur. Le modèle et l agent peuvent ne pas s appliquer à une session existante — ils prennent effet quand la tâche en crée une nouvelle. Le mode dépend du moteur.',
     'tb.bot':'Bot','tb.bot.none':'sans bot','tb.bot.tip':"La tâche s'exécute avec le prompt et le modèle de ce bot",
     'hdr.title':'Kanban','hdr.add':'Tâche',
     'proj.label':'Projet :','proj.all':'— Tous les projets —','proj.recent':'Récents','proj.search':'Rechercher un projet…','search.empty':'Aucun résultat',
@@ -649,7 +649,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Abonnement','tmux.required':'tmux est requis sur le serveur',
   },
   he: {
-    'modal.task_cfg':'הגדרות הרצה','modal.task_cfg_note':'חלים על ההרצה הבאה: תורות, מאמץ, מנוע. מודל, מצב וסוג הסוכן חלים רק כשהמשימה יוצרת סשן חדש — סשן קיים שומר על שלו.',
+    'modal.task_cfg':'הגדרות הרצה','modal.task_cfg_note':'חלים על ההרצה הבאה: תורות, מאמץ, מנוע. מודל וסוג הסוכן עשויים שלא לחול על סשן קיים — הם נכנסים לתוקף כשהמשימה יוצרת סשן חדש. המצב תלוי במנוע.',
     'tb.bot':'בוט','tb.bot.none':'ללא בוט','tb.bot.tip':'המשימה תרוץ עם הפרומפט והמודל של הבוט הזה',
     'hdr.title':'קנבן','hdr.add':'משימה',
     'proj.label':'פרויקט:','proj.all':'— כל הפרויקטים —','proj.recent':'אחרונים','proj.search':'חיפוש פרויקט...','search.empty':'לא נמצא',

--- a/public/kanban.html
+++ b/public/kanban.html
@@ -457,7 +457,7 @@ textarea.inp{ resize:vertical; min-height:80px; }
 // ─── i18n ─────────────────────────────────────────────────────────────────
 const TR = {
   uk: {
-    'modal.task_cfg':'Параметри запуску','modal.task_cfg_note':'Діють на наступний запуск. Модель уже створеної сесії не змінюється — нова модель застосується до наступної сесії цієї задачі.',
+    'modal.task_cfg':'Параметри запуску','modal.task_cfg_note':'Діють на наступний запуск: ліміт кроків, зусилля, двигун. Модель, режим і тип агента застосовуються лише коли задача створює НОВУ сесію — наявна сесія лишає свої.',
     'tb.bot':'Бот','tb.bot.none':'без бота','tb.bot.tip':'Задача виконається промптом і моделлю цього бота',
     'hdr.title':'Kanban','hdr.add':'Завдання',
     'proj.label':'Проект:','proj.all':'— Всі проекти —','proj.recent':'Нещодавні','proj.search':'Пошук проекту...','search.empty':'Не знайдено',
@@ -505,7 +505,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Підписка','tmux.required':'Потрібен tmux на сервері',
   },
   en: {
-    'modal.task_cfg':'Run settings','modal.task_cfg_note':'Applied on the next run. An existing session keeps its own model — a new model applies to the next session this task creates.',
+    'modal.task_cfg':'Run settings','modal.task_cfg_note':'Applied on the next run: turns, effort, engine. Model, mode and agent apply only when the task creates a NEW session — an existing session keeps its own.',
     'tb.bot':'Bot','tb.bot.none':'no bot','tb.bot.tip':'The task runs with this bot\'s prompt and model',
     'hdr.title':'Kanban','hdr.add':'Task',
     'proj.label':'Project:','proj.all':'— All projects —','proj.recent':'Recent','proj.search':'Search project...','search.empty':'Not found',
@@ -553,7 +553,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Subscription','tmux.required':'tmux is required on the server',
   },
   ru: {
-    'modal.task_cfg':'Параметры запуска','modal.task_cfg_note':'Применяются к следующему запуску. Модель уже созданной сессии не меняется — новая модель применится к следующей сессии этой задачи.',
+    'modal.task_cfg':'Параметры запуска','modal.task_cfg_note':'Применяются к следующему запуску: лимит шагов, усилие, движок. Модель, режим и тип агента применяются только когда задача создаёт НОВУЮ сессию — существующая сохраняет свои.',
     'tb.bot':'Бот','tb.bot.none':'без бота','tb.bot.tip':'Задача выполнится промптом и моделью этого бота',
     'hdr.title':'Kanban','hdr.add':'Задача',
     'proj.label':'Проект:','proj.all':'— Все проекты —','proj.recent':'Недавние','proj.search':'Поиск проекта...','search.empty':'Не найдено',
@@ -601,7 +601,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Подписка','tmux.required':'Нужен tmux на сервере',
   },
   fr: {
-    'modal.task_cfg':'Paramètres d exécution','modal.task_cfg_note':'Appliqués au prochain lancement. Une session existante conserve son modèle — le nouveau modèle s appliquera à la prochaine session de cette tâche.',
+    'modal.task_cfg':'Paramètres d exécution','modal.task_cfg_note':'Appliqués au prochain lancement : tours, effort, moteur. Le modèle, le mode et l agent ne s appliquent que lorsque la tâche crée une NOUVELLE session — une session existante conserve les siens.',
     'tb.bot':'Bot','tb.bot.none':'sans bot','tb.bot.tip':"La tâche s'exécute avec le prompt et le modèle de ce bot",
     'hdr.title':'Kanban','hdr.add':'Tâche',
     'proj.label':'Projet :','proj.all':'— Tous les projets —','proj.recent':'Récents','proj.search':'Rechercher un projet…','search.empty':'Aucun résultat',
@@ -649,7 +649,7 @@ const TR = {
     'engine.api':'API','engine.sub':'Abonnement','tmux.required':'tmux est requis sur le serveur',
   },
   he: {
-    'modal.task_cfg':'הגדרות הרצה','modal.task_cfg_note':'חלות על ההרצה הבאה. סשן קיים שומר על המודל שלו — מודל חדש יחול על הסשן הבא של משימה זו.',
+    'modal.task_cfg':'הגדרות הרצה','modal.task_cfg_note':'חלים על ההרצה הבאה: תורות, מאמץ, מנוע. מודל, מצב וסוג הסוכן חלים רק כשהמשימה יוצרת סשן חדש — סשן קיים שומר על שלו.',
     'tb.bot':'בוט','tb.bot.none':'ללא בוט','tb.bot.tip':'המשימה תרוץ עם הפרומפט והמודל של הבוט הזה',
     'hdr.title':'קנבן','hdr.add':'משימה',
     'proj.label':'פרויקט:','proj.all':'— כל הפרויקטים —','proj.recent':'אחרונים','proj.search':'חיפוש פרויקט...','search.empty':'לא נמצא',

--- a/test/delegate-terminal.test.js
+++ b/test/delegate-terminal.test.js
@@ -235,16 +235,42 @@ check('a hostile model name cannot break out of its quotes', () => {
 // Every flag shape a real template uses. The first rule matched exactly ONE space,
 // so `--model  {model}` left the flag behind and it swallowed the prompt as its
 // argument — the failure this whole substitution exists to prevent.
+// A regex over the whole template got three shapes wrong at once, and one of them
+// was SILENT corruption rather than a visible break:
+//   --model "{model}"        with a value -> --model "'opus'"  (quotes reach the CLI)
+//   --model "{model}"        with none    -> --model ""        (empty flag)
+//   --model={model},{model}  with none    -> claude,           (command destroyed)
+// The substitution is token-wise now; these pin every shape both ways.
 check('the flag is dropped for every shape, not just the canonical one', () => {
   for (const tpl of ['claude --model {model} {prompt}',
                      'claude --model  {model} {prompt}',
                      'claude --model={model} {prompt}',
                      'claude -m {model} {prompt}',
-                     'claude {model} {prompt}']) {
+                     'claude {model} {prompt}',
+                     'claude --model "{model}" {prompt}',
+                     "claude --model '{model}' {prompt}",
+                     'claude --model={model},{model} {prompt}']) {
     assert.strictEqual(
       buildTerminalCommand({ template: tpl }, '/w', 'hi', 'linux', {}).split('&& ')[1],
       "claude 'hi'", tpl);
   }
+});
+
+check('a quoted placeholder does not nest quotes around the value', () => {
+  // The value is shell-escaped here; quoting it again would hand the CLI a model
+  // literally named "'opus'".
+  for (const tpl of ['claude --model "{model}" {prompt}', "claude --model '{model}' {prompt}"]) {
+    assert.strictEqual(
+      buildTerminalCommand({ template: tpl }, '/w', 'hi', 'linux', { model: 'opus' }).split('&& ')[1],
+      "claude --model 'opus' 'hi'", tpl);
+  }
+});
+
+check('dropping one placeholder leaves the others intact', () => {
+  const tpl = 'claude --model {model} --effort {effort} -p {prompt}';
+  assert.strictEqual(
+    buildTerminalCommand({ template: tpl }, '/w', 'hi', 'linux', { effort: 'high' }).split('&& ')[1],
+    "claude --effort 'high' -p 'hi'");
 });
 
 if (failed) { console.log(`\n${failed} test(s) failed`); process.exit(1); }

--- a/test/delegate-terminal.test.js
+++ b/test/delegate-terminal.test.js
@@ -266,6 +266,16 @@ check('a quoted placeholder does not nest quotes around the value', () => {
   }
 });
 
+// The first token-wise version squeezed ALL whitespace after substituting, which
+// rewrites spacing a template author meant to keep. The drop path already inserts
+// exactly one space where a token was removed, so the squeeze was never needed.
+check('spacing elsewhere in the template survives', () => {
+  assert.strictEqual(
+    buildTerminalCommand({ template: 'claude --system "a  b" --model {model} {prompt}' },
+      '/w', 'hi', 'linux', { model: 'opus' }).split('&& ')[1],
+    "claude --system \"a  b\" --model 'opus' 'hi'");
+});
+
 check('dropping one placeholder leaves the others intact', () => {
   const tpl = 'claude --model {model} --effort {effort} -p {prompt}';
   assert.strictEqual(

--- a/test/kanban-schedule.test.js
+++ b/test/kanban-schedule.test.js
@@ -148,6 +148,12 @@ console.log('\nwhich task dials each run path actually receives:');
   };
   const api = callArgs('cli.send(');
   const sub = callArgs('runInteractiveSingle(');
+  // Assert BOTH were found before asserting anything about their contents. A miss
+  // returns '' and every "does NOT receive" check then passes vacuously — the pin
+  // would go green while measuring nothing, which is the failure mode this whole
+  // file keeps running into. The 20000-char window is the likely cause if it trips.
+  check('the API call site was located', api.length > 40, true);
+  check('the subscription call site was located', sub.length > 40, true);
   const has = (call, key) => new RegExp('[\\s{,]' + key + '\\s*:').test(call);
 
   // The API path is where turns and effort live.

--- a/test/kanban-schedule.test.js
+++ b/test/kanban-schedule.test.js
@@ -119,8 +119,47 @@ console.log('\nKanban task run settings remain editable:');
 
   // model is the one dial the session wins on (`session?.model || task.model`),
   // so the form has to say that rather than imply the change takes effect now.
-  check('the note explains what model does on an existing session',
+  check('the form carries a note about when the settings take effect',
     /modal\.task_cfg_note/.test(form), true);
+}
+
+// ── Which dial reaches which engine — read from the code, not guessed ──────
+// Three attempts at wording this note were each factually wrong, because the two
+// engines take DIFFERENT subsets and no single sentence covered both. The note now
+// says only what is always true; this pins the underlying matrix so the next person
+// reads it instead of guessing, and notices if a run path starts or stops
+// forwarding one of these.
+console.log('\nwhich task dials each run path actually receives:');
+{
+  const fs2 = require('fs'), path2 = require('path');
+  const SRV = fs2.readFileSync(path2.join(__dirname, '..', 'server.js'), 'utf8');
+  const i2 = SRV.indexOf('async function startTask(task)');
+  const seg = SRV.slice(i2, i2 + 20000);
+  const callArgs = (needle) => {
+    const k = seg.indexOf(needle);
+    if (k === -1) return '';
+    let d = 0, j = k + needle.length;
+    for (; j < seg.length; j++) {
+      const c = seg[j];
+      if (c === '(') d++;
+      else if (c === ')') { if (d === 0) break; d--; }
+    }
+    return seg.slice(k, j);
+  };
+  const api = callArgs('cli.send(');
+  const sub = callArgs('runInteractiveSingle(');
+  const has = (call, key) => new RegExp('[\\s{,]' + key + '\\s*:').test(call);
+
+  // The API path is where turns and effort live.
+  check('API run receives maxTurns', has(api, 'maxTurns'), true);
+  check('API run receives effort', has(api, 'effort'), true);
+  check('API run does NOT receive mode', has(api, 'mode'), false);
+  // The subscription path is the mirror image.
+  check('subscription run receives mode', has(sub, 'mode'), true);
+  check('subscription run does NOT receive maxTurns', has(sub, 'maxTurns'), false);
+  check('subscription run does NOT receive effort', has(sub, 'effort'), false);
+  // agent_mode reaches neither: it is read only when the session is first created.
+  check('neither run path receives agentMode', has(api, 'agentMode') || has(sub, 'agentMode'), false);
 }
 
 console.log(`\n${pass} passed, ${fail} failed`);


### PR DESCRIPTION
Four rounds of adversarial review over what shipped as v7.13.0. Five defects, one of them a UI note that took **three attempts** to state truthfully.

## The note that kept being wrong

I added a note to the Kanban task form explaining which settings take effect when. Three versions, three different falsehoods — because the sentence was trying to describe a matrix, and no dial behaves the same on both engines except `model`:

| dial | API run (`cli.send`) | subscription run (`runInteractiveSingle`) |
|---|---|---|
| turns, effort | forwarded | **not forwarded** |
| mode | **not forwarded** | forwarded |
| agent | neither — read only when the session is first created |

The note now says only what is true in every combination: changes are saved, they affect the next run rather than the one in progress, and which dials take effect depends on the engine and on whether the task already has a session.

**The matrix is pinned instead of restated** — `test/kanban-schedule.test.js` reads it out of the two call sites' argument lists, so the next person reads the code rather than guessing as I did three times, and it fails if a run path starts or stops forwarding one of these.

## Two silent corruptions in the delegate template substitution

Both from using a regex where token boundaries mattered:

- `--model "{model}"` **with** a value produced `--model "'opus'"`. The value is shell-escaped here, so quoting it again nests the quotes and the CLI receives a model literally named `'opus'`. No error — wrong model.
- `--model={model},{model}` with nothing chosen left `claude,` — the comma became part of the executable name.

Substitution now walks whitespace-separated tokens, so each is a local decision, and quotes an author wrapped around a placeholder are unwrapped before substituting. Thirteen shapes pinned, with and without a value, on POSIX and Windows.

A first attempt at that also squeezed all whitespace afterwards, which rewrites spacing a template author meant to keep (`--system "a  b"`). Removed — the drop path already inserts exactly one space where a token was removed.

## The pin that could pass while measuring nothing

Round 4 caught a weakness in my own test: the matrix pin searches a 20000-char window, and a miss returns `''`, after which every "does NOT receive" assertion passes against an empty string. It now asserts both call sites were located first. Verified by shrinking the window to 2000 — the suite goes red.

## Verification

Full suite in a CI-equivalent container (Linux, Node 20, no git identity): exit 0. Every new pin was checked to **fail** against the pre-fix code.